### PR TITLE
Added reusable cla check

### DIFF
--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -10,11 +10,9 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
-        required: true
       PERSONAL_ACCESS_TOKEN:
         required: true
-        
+
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -3,7 +3,7 @@ name: "CLA Check Workflow"
 on:
   workflow_call:
     secrets:
-      PERSONAL_ACCESS_TOKEN:
+      CLA_ACTION_ACCESS_TOKEN:
         required: true
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CLA_ACTION_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -9,11 +9,6 @@ on:
       github_event_payload:
         required: true
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
-      PERSONAL_ACCESS_TOKEN:
-        required: true
 
 jobs:
   CLAAssistant:
@@ -25,7 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ inputs.personal_access_token }}
+          CLA_ACTION_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -2,13 +2,6 @@ name: "CLA Check Workflow"
 
 on:
   workflow_call:
-    inputs:
-      github_event_name:
-        required: true
-        type: string
-      github_event_payload:
-        required: true
-        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
@@ -18,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        # Use conditionals to check for specific events or event details passed as inputs
-        if: ${{ inputs.github_event_name == 'pull_request_target' || contains(fromJson(inputs.github_event_payload).comment.body, 'recheck') || contains(fromJson(inputs.github_event_payload).comment.body, 'I have read the CLA Document and I hereby sign the CLA') }}
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -2,9 +2,6 @@ name: "CLA Check Workflow"
 
 on:
   workflow_call:
-    secrets:
-      PERSONAL_ACCESS_TOKEN:
-        required: true
 
 jobs:
   CLAAssistant:

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN   }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -9,7 +9,12 @@ on:
       github_event_payload:
         required: true
         type: string
-
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+        
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
@@ -20,7 +25,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN   }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"

--- a/.github/workflows/reusable-cla-check.yaml
+++ b/.github/workflows/reusable-cla-check.yaml
@@ -2,6 +2,9 @@ name: "CLA Check Workflow"
 
 on:
   workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
 
 jobs:
   CLAAssistant:

--- a/.github/workflows/reusable-cla-check.yml
+++ b/.github/workflows/reusable-cla-check.yml
@@ -1,0 +1,33 @@
+name: "CLA Assistant"
+on:
+  workflow_call:
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/pimcore/pimcore/blob/master/CLA.md' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          allowlist: user1,bot*
+
+          remote-organization-name: 'pimcore'
+          remote-repository-name: 'cla'
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/reusable-cla-check.yml
+++ b/.github/workflows/reusable-cla-check.yml
@@ -8,26 +8,17 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.1
+        uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/pimcore/pimcore/blob/master/CLA.md' # e.g. a CLA or a DCO document
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: 'main'
+          branch: "main"
           allowlist: user1,bot*
 
-          remote-organization-name: 'pimcore'
-          remote-repository-name: 'cla'
-
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA
+          remote-organization-name: "pimcore"
+          remote-repository-name: "cla"

--- a/.github/workflows/reusable-cla-check.yml
+++ b/.github/workflows/reusable-cla-check.yml
@@ -1,24 +1,35 @@
-name: "CLA Assistant"
+name: "CLA Check Workflow"
+
 on:
   workflow_call:
+    inputs:
+      github_event_name:
+        required: true
+        type: string
+      github_event_payload:
+        required: true
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      PERSONAL_ACCESS_TOKEN:
+        required: true
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Use conditionals to check for specific events or event details passed as inputs
+        if: ${{ inputs.github_event_name == 'pull_request_target' || contains(fromJson(inputs.github_event_payload).comment.body, 'recheck') || contains(fromJson(inputs.github_event_payload).comment.body, 'I have read the CLA Document and I hereby sign the CLA') }}
         uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ inputs.personal_access_token }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
-          path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md" # e.g. a CLA or a DCO document
-          # branch should not be protected
+          path-to-document: "https://github.com/pimcore/pimcore/blob/master/CLA.md"
           branch: "main"
           allowlist: user1,bot*
-
           remote-organization-name: "pimcore"
           remote-repository-name: "cla"


### PR DESCRIPTION
https://pimcore.atlassian.net/browse/SOLI-97

Added reusable CLA check workflow
Bumped CLA action version to latest one from action release repo

example usage of new CLA within dependent workflow

> name: "CLA Assistant"
> on:
>   issue_comment:
>     types: [created]
>   pull_request_target:
>     types: [opened,closed,synchronize]
> jobs:
>   cla-check:
>       uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yml@cla_check

After this PR has been merged, new release will be created and dependent workflows will reference versioned one