### PR TITLE
Upload artifact version upgrade

### DIFF
--- a/.github/workflows/reusable-static-analysis-centralized.yaml
+++ b/.github/workflows/reusable-static-analysis-centralized.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: "Upload baseline file"
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
             name: phpstan-baseline.neon
             path: phpstan-baseline.neon


### PR DESCRIPTION
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

https://github.com/actions/upload-artifact