### PR TITLE
Fixed wrong branch name in the Teams report title

### DIFF
--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -116,7 +116,7 @@ jobs:
               uses: aliencube/microsoft-teams-actions@v0.8.0
               with:
                 webhook_uri: ${{ secrets.TEAMS_COMPOSER_OUTDATED_URI }}
-                title: ${{ github.repository }}@${{ github.ref_name }} outdated - vulnerabilities report
+                title: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
                 summary: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}} 
                 text: |
                   Please check the following link for details: 

--- a/.github/workflows/reusable-composer-vulnerabilities.yaml
+++ b/.github/workflows/reusable-composer-vulnerabilities.yaml
@@ -136,7 +136,7 @@ jobs:
               uses: aliencube/microsoft-teams-actions@v0.8.0
               with:
                 webhook_uri: ${{ secrets.TEAMS_COMPOSER_VULNERABILITY_URI }}
-                title: ${{ github.repository }}@${{ github.ref_name }} outdated - vulnerabilities report
+                title: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
                 summary: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}} 
                 text: |
                   Please check the following link for details: 


### PR DESCRIPTION
Now using real inputs.branch instead of github.ref_name