### PR TITLE
Update reusable-codeception-public.yaml

### DIFF
--- a/.github/workflows/reusable-codeception-public.yaml
+++ b/.github/workflows/reusable-codeception-public.yaml
@@ -96,10 +96,16 @@ jobs:
                     MYSQL_ALLOW_EMPTY_PASSWORD: yes
 
         steps:
-            - name: "Checkout code"
+            
+            - name: Checkout PR head (only for pull_request_target)
+              if: github.event_name == 'pull_request_target'
               uses: "actions/checkout@v4"
               with:
-                repository: ${{ inputs.repository}}
+                  ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
+
+            - name: Checkout PR head (for push or other events)
+              if: github.event_name != 'pull_request_target'
+              uses: "actions/checkout@v4"
 
             - uses: "actions/setup-node@v4"
               with:


### PR DESCRIPTION
Checkout the merge commit when `pull_request_target` is used, to make sure, that we dont run into problems using secrets like product key.