### PR TITLE
Switch to minio official image

### DIFF
--- a/.github/workflows/reusable-codeception-public.yaml
+++ b/.github/workflows/reusable-codeception-public.yaml
@@ -91,16 +91,13 @@ jobs:
         continue-on-error: ${{ inputs.experimental }}
         services:
             minio:
-                image: bitnamilegacy/minio:latest
+                image: minio/minio:latest
                 ports:
                     - 9000:9000
+                    - 9001:9001
                 env:
                     MINIO_ROOT_USER: "${{ env.MINIO_ACCESS_KEY }}"
                     MINIO_ROOT_PASSWORD: "${{ env.MINIO_SECRET_KEY }}"
-                    MINIO_SERVER_ACCESS_KEY: "${{ env.MINIO_ACCESS_KEY }}"
-                    MINIO_SERVER_SECRET_KEY: "${{ env.MINIO_SECRET_KEY }}"
-                    MINIO_DEFAULT_BUCKETS: "asset,assetcache,thumbnail,version,recyclebin,admin,emaillog,temp,applicationlog"
-                options: --name minio-server
             redis:
                 image: redis
                 ports:
@@ -117,6 +114,15 @@ jobs:
               uses: "actions/checkout@v4"
               with:
                 repository: ${{ inputs.repository}}
+
+            - name: "Setup minio buckets"
+              run: |
+                  curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc -o mc
+                  chmod +x mc
+                  ./mc alias set myminio http://localhost:9000 ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}
+                  for bucket in asset assetcache thumbnail version recyclebin admin emaillog temp applicationlog; do
+                      ./mc mb myminio/$bucket --ignore-existing
+                  done
 
             - uses: "actions/setup-node@v4"
               with:


### PR DESCRIPTION
This pull request updates the MinIO service configuration in the GitHub Actions workflow and introduces a step to explicitly set up required MinIO buckets. These changes ensure compatibility with the latest MinIO image and guarantee that all necessary buckets are created for tests.

**MinIO Service Updates:**

* Changed the MinIO Docker image from `bitnamilegacy/minio:latest` to the official `minio/minio:latest` and added port `9001` to the service configuration. This improves compatibility and exposes the MinIO admin console.

**Bucket Initialization:**

* Added a workflow step to download the MinIO client (`mc`) and create all required buckets (`asset`, `assetcache`, `thumbnail`, `version`, `recyclebin`, `admin`, `emaillog`, `temp`, `applicationlog`) before tests run, ensuring proper test environment setup.