### PR TITLE
Removed elastic

### DIFF
--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -129,15 +129,15 @@ jobs:
           discovery.type: "single-node"
           DISABLE_SECURITY_PLUGIN: true
 
-      elastic:
-        image: elasticsearch:${{ inputs.PIMCORE_ELASTIC_SEARCH_VERSION }}
-        ports:
-          - ${{ inputs.PIMCORE_ELASTIC_SEARCH_HOST }}:9200
-        env:
-          discovery.type: "single-node"
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-          xpack.security.enabled: "true"
-          xpack.security.authc.anonymous.roles: "superuser"
+      # elastic:
+      #   image: elasticsearch:${{ inputs.PIMCORE_ELASTIC_SEARCH_VERSION }}
+      #   ports:
+      #     - ${{ inputs.PIMCORE_ELASTIC_SEARCH_HOST }}:9200
+      #   env:
+      #     discovery.type: "single-node"
+      #     ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      #     xpack.security.enabled: "true"
+      #     xpack.security.authc.anonymous.roles: "superuser"
 
       gotenberg:
         image: gotenberg/gotenberg:8


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/reusable-codeception-tests-centralized.yaml` workflow file. The main change is that the configuration for the `elastic` service has been commented out, which means Elasticsearch will no longer be started as part of this workflow.

* Commented out the `elastic` service setup, including its image, ports, and environment variables, effectively disabling Elasticsearch in this workflow.