### PR TITLE
Codeception fix

### DIFF
--- a/.github/workflows/reusable-codeception-public.yaml
+++ b/.github/workflows/reusable-codeception-public.yaml
@@ -58,7 +58,7 @@ on:
         required: true
         type: string
       BRANCH_NAME:
-        required: true
+        required: false
         type: string        
     secrets:
       COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN:


### PR DESCRIPTION
Fixing the branch input name for the base branch. 

Should use base branch for checkout and running the codeception against it. 

