### PR TITLE
Added debug for branch name and repo

### DIFF
--- a/.github/workflows/reusable-codeception-public.yaml
+++ b/.github/workflows/reusable-codeception-public.yaml
@@ -118,10 +118,10 @@ jobs:
 
         steps:
 
-            - name: "Debug BRANCH_NAME"
+            - name: "Debug BRANCH_NAME and repository"
               run: |
                 echo "BRANCH_NAME: ${{ inputs.BRANCH_NAME }}"
-                echo "github.ref: ${{ github.ref }}"
+                echo "repository: ${{ inputs.repository }}"
 
             - name: "Checkout code"
               uses: "actions/checkout@v4"


### PR DESCRIPTION
This pull request makes a minor update to the debugging step in the `.github/workflows/reusable-codeception-public.yaml` workflow to improve visibility into the repository being used.

* The debug step now prints both the `BRANCH_NAME` and the `repository` input, instead of `github.ref`, to provide clearer information during workflow runs.