### PR TITLE
Fix symfony-freeze conflict for pimcore 2026+ and restore matrix config

### DIFF
--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -231,8 +231,16 @@ jobs:
       - name: "Check Symfony6 freeze requirement"
         env:
           TARGET_BRANCH: "${{ steps.branch-info.outputs.target_branch }}"
+          PIMCORE_VERSION: "${{ inputs.PIMCORE_VERSION }}"
         run: |
-          echo "Checking if Symfony6 freeze is needed for branch: $TARGET_BRANCH"
+          echo "Checking if Symfony6 freeze is needed for branch: $TARGET_BRANCH (PIMCORE_VERSION: $PIMCORE_VERSION)"
+          
+          # Check pimcore version from composer.json if no PIMCORE_VERSION input
+          COMPOSER_PIMCORE=""
+          if [ -f composer.json ]; then
+            COMPOSER_PIMCORE=$(php -r "\$j=json_decode(file_get_contents('composer.json'),true); echo \$j['require']['pimcore/pimcore'] ?? '';" 2>/dev/null || true)
+            echo "Pimcore constraint from composer.json: $COMPOSER_PIMCORE"
+          fi
           
           # Skip Symfony freeze if TARGET_BRANCH ends with ".x" or starts with "2026"
           if [[ "$TARGET_BRANCH" =~ \.x$ ]]; then
@@ -240,6 +248,12 @@ jobs:
             echo "SYMFONY_FREEZE_INSTALLED=false" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" =~ ^20(2[6-9]|[3-9][0-9]) ]]; then
             echo "Branch $TARGET_BRANCH starts with year 2026+, skipping Symfony6 freeze"
+            echo "SYMFONY_FREEZE_INSTALLED=false" >> $GITHUB_ENV
+          elif [[ "$PIMCORE_VERSION" =~ ^20(2[6-9]|[3-9][0-9]) ]]; then
+            echo "PIMCORE_VERSION $PIMCORE_VERSION targets year 2026+, skipping Symfony6 freeze"
+            echo "SYMFONY_FREEZE_INSTALLED=false" >> $GITHUB_ENV
+          elif [[ "$COMPOSER_PIMCORE" =~ 20(2[6-9]|[3-9][0-9]) ]]; then
+            echo "composer.json pimcore constraint '$COMPOSER_PIMCORE' targets year 2026+, skipping Symfony6 freeze"
             echo "SYMFONY_FREEZE_INSTALLED=false" >> $GITHUB_ENV
           else
             echo "Installing pimcore/symfony-freeze:^6.0.1 for branch: $TARGET_BRANCH"

--- a/codeception-tests-configuration/matrix-contig-mariadb-only.json
+++ b/codeception-tests-configuration/matrix-contig-mariadb-only.json
@@ -97,10 +97,36 @@
           "es_version": "8.4.3"
         },
         {
+          "php-version": "8.3",
+          "database": "mariadb:10.7",
+          "dependencies": "lowest",
+          "experimental": "false",
+          "require_admin_bundle" : "true",
+          "es_version": "8.4.3"
+        },
+        {
           "php-version": "8.4",
           "database": "mariadb:10.7",
           "dependencies": "highest",
           "experimental": "false",
+          "require_admin_bundle" : "true",
+          "es_version": "8.4.3"
+        },
+        {
+          "php-version": "8.4",
+          "database": "mariadb:10.7",
+          "dependencies": "highest",
+          "pimcore_version": "2026.x-dev as 12.99.9",
+          "experimental": "true",
+          "require_admin_bundle" : "true",
+          "es_version": "8.4.3"
+        },
+        {
+          "php-version": "8.4",
+          "database": "mariadb:10.7",
+          "dependencies": "highest",
+          "pimcore_version": "2026.x-dev as 12.99.9",
+          "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3"
         }
@@ -118,10 +144,27 @@
           "es_version": "8.4.3"
         },
         {
+          "php-version": "8.4",
+          "database": "mariadb:10.7",
+          "dependencies": "lowest",
+          "experimental": "false",
+          "require_admin_bundle" : "true",
+          "es_version": "8.4.3"
+        },
+        {
           "php-version": "8.5",
           "database": "mariadb:10.7",
           "dependencies": "highest",
           "experimental": "false",
+          "require_admin_bundle" : "true",
+          "es_version": "8.4.3"
+        },
+        {
+          "php-version": "8.5",
+          "database": "mariadb:10.7",
+          "dependencies": "highest",
+          "pimcore_version": "2026.x-dev as 12.99.9",
+          "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3"
         },


### PR DESCRIPTION
Skip symfony-freeze:^6.0.1 when pimcore 2026+ is detected via:
- Branch name (existing: .x suffix or 2026+ prefix)
- PIMCORE_VERSION input (matrix-injected versions)
- composer.json pimcore constraint (repos requiring pimcore 2026+ directly)

Restore mariadb-only matrix config to original state since the workflow now handles the freeze skip correctly.