### PR TITLE
Change 2026.x as 12.99.99 from PHP >= 8.4 matrix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @bluvulture @brusch @herbertroth
-*.yml @bluvulture @brusch
+* @bluvulture @brusch @herbertroth @berfinyuksel
+*.yml @bluvulture @brusch 
 *.yaml @bluvulture @brusch

--- a/codeception-tests-configuration/matrix-config.json
+++ b/codeception-tests-configuration/matrix-config.json
@@ -67,7 +67,7 @@
           "php-version": "8.4",
           "database": "mariadb:10.7",
           "dependencies": "highest",
-          "pimcore_version": "2026.x-dev as 12.99.9",
+          "pimcore_version": "12.3.x-dev as 12.99.9",
           "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3",

--- a/codeception-tests-configuration/matrix-contig-mariadb-only.json
+++ b/codeception-tests-configuration/matrix-contig-mariadb-only.json
@@ -57,7 +57,7 @@
           "php-version": "8.4",
           "database": "mariadb:10.7",
           "dependencies": "highest",
-          "pimcore_version": "2026.x-dev as 12.99.9",
+          "pimcore_version": "12.3.x-dev as 12.99.9",
           "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3"
@@ -116,7 +116,7 @@
           "php-version": "8.4",
           "database": "mariadb:10.7",
           "dependencies": "highest",
-          "pimcore_version": "2026.x-dev as 12.99.9",
+          "pimcore_version": "12.3.x-dev as 12.99.9",
           "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3"
@@ -125,7 +125,7 @@
           "php-version": "8.4",
           "database": "mariadb:10.7",
           "dependencies": "highest",
-          "pimcore_version": "2026.x-dev as 12.99.9",
+          "pimcore_version": "12.3.x-dev as 12.99.9",
           "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3"

--- a/codeception-tests-configuration/matrix-contig-mariadb-only.json
+++ b/codeception-tests-configuration/matrix-contig-mariadb-only.json
@@ -203,7 +203,7 @@
           "php-version": "8.4",
           "database": "mariadb:10.7",
           "dependencies": "highest",
-          "pimcore_version": "2026.x-dev as 12.99.9",
+          "pimcore_version": "12.3.x-dev as 12.99.9",
           "experimental": "true",
           "require_admin_bundle" : "true",
           "es_version": "8.4.3"


### PR DESCRIPTION
Remove leftover that 2026.x is used as alias for 12.99.99 for (8.1 - 8.4) when running on the 2025.4 LTS

See https://github.com/pimcore/ee-customer-data-framework/actions/runs/24660219698/workflow?pr=101