### PR TITLE
Skip studio frontend build workflow on tag pushes

### DIFF
--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -62,6 +62,7 @@ env:
 
 jobs:
   install:
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -161,9 +162,10 @@ jobs:
 
   build:
     needs:
+      - install
       - lint
       - check-types
-    if: ${{ always() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.check-types.result == 'success' || needs.check-types.result == 'skipped') }}
+    if: ${{ always() && needs.install.result == 'success' && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.check-types.result == 'success' || needs.check-types.result == 'skipped') }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
When triggered by a tag push, actions/checkout landed in detached HEAD at refs/tags/<tag> and git-auto-commit-action attempted git push origin HEAD:<tag>. Since the tag already exists remotely, the push was rejected with "! [rejected] HEAD -> v2026.1.1 (already exists)", causing every release-tag run across consumer repos to fail.

Fix: gate the install job with if: !startsWith(github.ref, refs/tags/), which cascades to lint and check-types via needs. Also add install to build.needs and require needs.install.result == success so the always() condition no longer lets build run when install was skipped (pre-existing latent issue).

On tag pushes the workflow is now skipped cleanly. Branch pushes, PRs, and workflow_dispatch are unaffected. Complements #84, which fixed detached HEAD handling for branch/PR runs but not tag pushes.