### PR TITLE
fix(osv-checks): disable audit.block-insecure to keep solver decoupled from advisory state

### DIFF
--- a/.github/workflows/reusable-osv-checks.yaml
+++ b/.github/workflows/reusable-osv-checks.yaml
@@ -67,6 +67,16 @@ jobs:
         run: |
           composer config minimum-stability dev
           composer config prefer-stable true
+          # Disable Composer's audit-based pool filter so that package
+          # versions with open security advisories are not silently removed
+          # from the solver pool. OSV-Scanner (run later in this workflow)
+          # remains the source of truth for vulnerability reporting; allowing
+          # Composer to still resolve them is required so the SBOM reflects
+          # the actual installable set. Without this, a single advisory with
+          # a wide "affectedVersions" range (e.g. <=12.3.x catching 11.5.x)
+          # makes dependency resolution fail before the SBOM can be built.
+          composer config audit.abandoned ignore
+          composer config audit.block-insecure false
 
       - name: Read and modify composer.json
         id: update_composer


### PR DESCRIPTION
## Problem

The reusable OSV checks workflow (`reusable-osv-checks.yaml`) started failing intermittently for older platform-version matrix entries (e.g. `v2024.4`) on 2026-05-27 with errors like:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - pimcore/platform-version is present at version v2024.4 and cannot be modified by Composer
    - Root composer.json requires pimcore/workflow-designer * -> satisfiable by pimcore/workflow-designer[..., v1.4.2, ..., 2026.x-dev].
    - pimcore/platform-version v2024.4 conflicts with pimcore/pimcore 11.5.x-dev.
    - pimcore/platform-version v2024.4 conflicts with pimcore/pimcore 11.4.x-dev.
    - pimcore/platform-version v2024.4 conflicts with pimcore/pimcore 11.3.x-dev.
    - pimcore/workflow-designer[v1.4.0-RC1, ..., v1.4.2] require pimcore/pimcore ^11.2 -> satisfiable by pimcore/pimcore[11.3.x-dev, 11.4.x-dev, 11.5.x-dev].
```

## Root cause

Composer 2.9.x enables `audit.block-insecure` by default. This silently removes package versions with open security advisories from the solver pool **before** resolution starts.

## Fix

Disable the audit-based pool filter explicitly:

```yaml
composer config audit.abandoned ignore
composer config audit.block-insecure false
```