### PR TITLE
fix: restore private packagist auth for public repos

### DIFF
--- a/.github/workflows/reusable-static-analysis-unified.yaml
+++ b/.github/workflows/reusable-static-analysis-unified.yaml
@@ -17,10 +17,16 @@ on:
           {"include":[{"php-version":"8.2","dependencies":"highest","experimental":false}]}
 
       private_repo:
-        description: "Enable private repository authentication"
+        description: "Enable SSH key for private GitHub repository access"
         required: false
         type: string
         default: "false"
+
+      use_private_packagist:
+        description: "Configure auth for repo.pimcore.com private packagist"
+        required: false
+        type: string
+        default: "true"
 
       checkout_ref:
         description: "Git ref to checkout (auto-detects PR head if empty)"
@@ -114,7 +120,7 @@ jobs:
           known_hosts: ".... we add this in the next step ;-)"
 
       - name: "Add authentication for private pimcore packages"
-        if: ${{ inputs.private_repo == 'true' }}
+        if: ${{ inputs.use_private_packagist == 'true' }}
         run: |
           composer config repositories.private-packagist '{"type": "composer", "url": "https://repo.pimcore.com/github-actions/", "canonical": ${{ inputs.PRIVATE_PACKAGIST_CANONICAL }}}'
           composer config --global --auth http-basic.repo.pimcore.com github-actions ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}


### PR DESCRIPTION
Split private_repo (SSH key for private GitHub repos) from a new use_private_packagist input (packagist auth for repo.pimcore.com).

The June 1 == 'true' fix was correct in intent but broke all public repos that need enterprise packagist access. Use_private_packagist defaults to true, restoring the pre-regression behavior without reintroducing the truthy-string bug.