### PR TITLE
fix(static-analysis): add SSH known_hosts and HTTPS→SSH rewrite for private GitHub repos

### DIFF
--- a/.github/workflows/reusable-static-analysis-unified.yaml
+++ b/.github/workflows/reusable-static-analysis-unified.yaml
@@ -17,7 +17,7 @@ on:
           {"include":[{"php-version":"8.2","dependencies":"highest","experimental":false}]}
 
       private_repo:
-        description: "Enable SSH key for private GitHub repository access"
+        description: "Install SSH key to clone private GitHub repos during Composer install (independent of whether the calling repo itself is public or private)"
         required: false
         type: string
         default: "false"
@@ -118,6 +118,12 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
           known_hosts: ".... we add this in the next step ;-)"
+
+      - name: "Add GitHub to known_hosts and redirect HTTPS to SSH"
+        if: ${{ inputs.private_repo == 'true' }}
+        run: |
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global url."git@github.com:".insteadOf "https://github.com/"
 
       - name: "Add authentication for private pimcore packages"
         if: ${{ inputs.use_private_packagist == 'true' }}


### PR DESCRIPTION
When private_repo: 'true' is set, Composer can resolve pimcore/pimcore to the private pimcore/ee-pimcore GitHub repository. In that case, it needs to clone the repo during install.

The problem was that the existing SSH key setup was incomplete. It had a placeholder known_hosts value, but no step to actually add GitHub to known_hosts or force Git to use SSH. Because of that, Composer tried to clone the private repo over HTTPS and failed with:

Authentication failed for 'https://github.com/pimcore/ee-pimcore.git/'

This change fixes the issue in two ways:

It adds the missing “Add GitHub to known_hosts and redirect HTTPS to SSH” step, which only runs when private_repo == 'true'. This step:
Uses ssh-keyscan to add GitHub’s host key to known_hosts
Tells Git to rewrite https://github.com/ URLs to git@github.com:, so Composer uses the installed SSH key instead of HTTPS authentication
It clarifies what private_repo means. The flag does not describe whether the calling repository is public or private. It only controls whether Composer needs SSH access to install private GitHub dependencies.

For example, studio-backend-bundle is a public repo, but it depends on the private ee-pimcore repo. Because of that, it still needs to pass:

private_repo: 'true'