### PR TITLE
[Bugfix] Gate lowest-deps audit-block step on inputs.DEPENDENCIES, not matrix

### DIFF
--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -216,7 +216,7 @@ jobs:
           composer config --global --auth http-basic.repo.pimcore.com github-actions ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
 
       - name: "Configure Composer audit block insecure to false for lowest dependencies"
-        if: ${{ matrix.dependencies == 'lowest' }}
+        if: ${{ inputs.DEPENDENCIES == 'lowest' }}
         run: composer config audit.block-insecure false
 
       - name: "Update Pimcore version"


### PR DESCRIPTION
### Problem

In `reusable-codeception-tests-centralized.yaml`, the step **"Configure Composer audit block insecure to false for lowest dependencies"** is gated on:

```yaml
if: ${{ matrix.dependencies == 'lowest' }}
```

This is a **reusable (called) workflow**, where the `matrix` context isn't available — `dependencies` arrives as the `DEPENDENCIES` **input** (and the install step already uses `${{ inputs.DEPENDENCIES }}`). So the condition is always false, the step is skipped, and `composer config audit.block-insecure false` never runs.

That was harmless until the pinned **lowest** floor versions (e.g. `pimcore/pimcore` 11.2.0, `admin-ui-classic-bundle` 1.0.0) accumulated published security advisories — now Composer's advisory blocking refuses to install them and the `lowest` job fails dependency resolution. This currently breaks the `lowest` matrix run for every consuming repo (e.g. pimcore/ee-customer-data-framework#114).

### Fix

```yaml
if: ${{ inputs.DEPENDENCIES == 'lowest' }}
```

One line; restores the intended behaviour for the lowest-dependency run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)