### PR TITLE
[Bugfix] Disable Composer audit block for all dependency variants, not only lowest

### DIFF
--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -215,8 +215,10 @@ jobs:
           composer config repositories.private-packagist '{"type": "composer", "url": "https://repo.pimcore.com/github-actions/", "canonical": ${{ inputs.PRIVATE_PACKAGIST_CANONICAL }}}'
           composer config --global --auth http-basic.repo.pimcore.com github-actions ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
 
-      - name: "Configure Composer audit block insecure to false for lowest dependencies"
-        if: ${{ inputs.DEPENDENCIES == 'lowest' }}
+      - name: "Configure Composer audit block insecure to false"
+        # CI must be able to install the pinned dependency versions even when they are affected by
+        # published advisories — supported LTS lines (e.g. Pimcore 11.x) carry open advisories
+        # across their whole version range, so this applies to highest and lowest alike.
         run: composer config audit.block-insecure false
 
       - name: "Update Pimcore version"


### PR DESCRIPTION
### Follow-up to the `inputs.DEPENDENCIES` fix

That fix made the audit-block-disable step run for the **lowest** job. The **highest** job still fails composer resolution:

```
Your requirements could not be resolved...
- pimcore/admin-ui-classic-bundle ^1.0 [v1.0.0 … v1.7.18] not loaded, affected by security advisories
- pimcore/pimcore ^11.2 [v11.2.0 … v11.5.18] not loaded, affected by security advisories
```

Supported **LTS lines (Pimcore 11.x, admin-ui 1.x)** now have published advisories across their *whole* version range, so even the highest allowed versions are blocked. CI must still install them to run the suite.

### Fix

Drop the `if: lowest` condition so `composer config audit.block-insecure false` runs for every dependency variant. For lines without advisories it's a no-op (nothing to block).

Side benefit: with `highest` resolving again, its failure no longer fail-fast-cancels the `lowest` job (the reusable workflow's `continue-on-error` for `EXPERIMENTAL` doesn't propagate to the caller's matrix job).

Unblocks e.g. pimcore/ee-customer-data-framework#114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)