### PR TITLE
Add reusable PR guardrail pipeline (membership / issue-link / CI)

### DIFF
--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -6,9 +6,9 @@ name: "PR Guardrails pipeline"
 # is inherited from the caller's pull_request_target / check_suite event.
 #
 # Pipeline:
-#   membership  (PR events) ─► outputs.is_member
-#   issue-link  (PR events, only when NOT a Dev-Team member)   needs: membership
-#   ci          (PR + check_suite events, always)
+#   membership  (all events) ─► outputs.bypass
+#   issue-link  (PR events, only when not bypassed)   needs: membership
+#   ci          (PR + check_suite events, only when not bypassed)   needs: membership
 #
 # Each stage that fails converts the PR to draft and comments. Stages run
 # independently and report individually (a failure does not cancel later stages).
@@ -24,9 +24,10 @@ on:
         required: true
 
 jobs:
-  # Runs first on every event. If the PR author is a Dev-Team member, is_member
-  # becomes 'true' and ALL other guardrails are skipped (members are fully
-  # exempt). Skipped only on draft PRs from a pull_request_target event.
+  # Runs first on every event and emits `bypass`. bypass=true (so ALL other
+  # guardrails are skipped) when the author is a Dev-Team member, the PR carries
+  # the override label, or a Dev-Team member pressed "Ready for review".
+  # Skipped only on draft PRs from a pull_request_target event.
   membership:
     if: ${{ github.event_name == 'check_suite' || (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) }}
     uses: ./.github/workflows/reusable-guardrail-membership.yml
@@ -35,20 +36,18 @@ jobs:
 
   issue-link:
     needs: [membership]
-    # Non-draft PR events only, and only when the author is NOT a Dev-Team
-    # member. If membership was skipped/errored, is_member is empty -> issue-link
-    # runs (fail-safe: enforce rather than exempt).
-    if: ${{ always() && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.is_member != 'true' }}
+    # Non-draft PR events only, and only when not bypassed. If membership was
+    # skipped/errored, bypass is empty -> issue-link runs (fail-safe: enforce).
+    if: ${{ always() && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-issue-link.yml
     secrets:
       ISSUE_LINK_GUARD_TOKEN: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
 
   ci:
     needs: [membership]
-    # Runs on PR events and on check_suite completion, but never for members
-    # (is_member == 'true'). Empty is_member (membership skipped/errored) ->
-    # CI runs (fail-safe).
-    if: ${{ always() && needs.membership.outputs.is_member != 'true' }}
+    # Runs on PR events and on check_suite completion, but never when bypassed.
+    # Empty bypass (membership skipped/errored) -> CI runs (fail-safe).
+    if: ${{ always() && needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-ci.yml
     secrets:
       CI_GUARD_TOKEN: ${{ secrets.CI_GUARD_TOKEN }}

--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -29,7 +29,7 @@ jobs:
   # the override label, or a Dev-Team member pressed "Ready for review".
   # Skipped only on draft PRs from a pull_request_target event.
   membership:
-    if: ${{ github.event_name == 'check_suite' || (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) }}
+    if: ${{ github.event_name == 'check_suite' || (github.event_name == 'pull_request_target' && (github.event.pull_request.draft == false || github.event.action == 'converted_to_draft')) }}
     uses: ./.github/workflows/reusable-guardrail-membership.yml
     secrets:
       MEMBERSHIP_GUARD_TOKEN: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}

--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -1,0 +1,54 @@
+name: "PR Guardrails pipeline"
+
+# Orchestrator for the PR guardrail pipeline. Consumer repos call this via a
+# thin, generic trigger workflow with `secrets: inherit` (so adding a guardrail
+# or token never requires editing the consumer repos). The github context here
+# is inherited from the caller's pull_request_target / check_suite event.
+#
+# Pipeline:
+#   membership  (PR events) ─► outputs.is_member
+#   issue-link  (PR events, only when NOT a Dev-Team member)   needs: membership
+#   ci          (PR + check_suite events, always)
+#
+# Each stage that fails converts the PR to draft and comments. Stages run
+# independently and report individually (a failure does not cancel later stages).
+
+on:
+  workflow_call:
+    secrets:
+      MEMBERSHIP_GUARD_TOKEN:
+        required: true
+      ISSUE_LINK_GUARD_TOKEN:
+        required: true
+      CI_GUARD_TOKEN:
+        required: true
+
+jobs:
+  # Runs first on every event. If the PR author is a Dev-Team member, is_member
+  # becomes 'true' and ALL other guardrails are skipped (members are fully
+  # exempt). Skipped only on draft PRs from a pull_request_target event.
+  membership:
+    if: ${{ github.event_name == 'check_suite' || (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) }}
+    uses: ./.github/workflows/reusable-guardrail-membership.yml
+    secrets:
+      MEMBERSHIP_GUARD_TOKEN: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}
+
+  issue-link:
+    needs: [membership]
+    # Non-draft PR events only, and only when the author is NOT a Dev-Team
+    # member. If membership was skipped/errored, is_member is empty -> issue-link
+    # runs (fail-safe: enforce rather than exempt).
+    if: ${{ always() && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.is_member != 'true' }}
+    uses: ./.github/workflows/reusable-guardrail-issue-link.yml
+    secrets:
+      ISSUE_LINK_GUARD_TOKEN: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
+
+  ci:
+    needs: [membership]
+    # Runs on PR events and on check_suite completion, but never for members
+    # (is_member == 'true'). Empty is_member (membership skipped/errored) ->
+    # CI runs (fail-safe).
+    if: ${{ always() && needs.membership.outputs.is_member != 'true' }}
+    uses: ./.github/workflows/reusable-guardrail-ci.yml
+    secrets:
+      CI_GUARD_TOKEN: ${{ secrets.CI_GUARD_TOKEN }}

--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -49,5 +49,9 @@ jobs:
     # Empty bypass (membership skipped/errored) -> CI runs (fail-safe).
     if: ${{ always() && needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-ci.yml
+    with:
+      # Skip individually-bypassed PRs (e.g. a member PR sharing a check_suite
+      # with a non-member PR, where the aggregate gate still lets CI run).
+      bypassed_prs: ${{ needs.membership.outputs.bypassed_prs || '[]' }}
     secrets:
       CI_GUARD_TOKEN: ${{ secrets.CI_GUARD_TOKEN }}

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -11,6 +11,12 @@ name: "Reusable Guardrail: CI & merge readiness"
 
 on:
   workflow_call:
+    inputs:
+      bypassed_prs:
+        description: "JSON array of PR numbers that are bypassed (member/override) and must be skipped"
+        required: false
+        type: string
+        default: "[]"
     secrets:
       CI_GUARD_TOKEN:
         required: true
@@ -36,11 +42,19 @@ jobs:
           path: _central
 
       - uses: actions/github-script@v7
+        env:
+          BYPASSED_PRS: ${{ inputs.bypassed_prs }}
         with:
           github-token: ${{ secrets.CI_GUARD_TOKEN }}
           script: |
             const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
             const marker = 'guardrail:ci-status';
+
+            // PRs the membership stage marked as bypassed (member author / override).
+            // On a check_suite shared by multiple PRs, the aggregate gate may let CI
+            // run; skip those individual PRs here so an exempt PR is never drafted.
+            let bypassedPrs = [];
+            try { bypassedPrs = JSON.parse(process.env.BYPASSED_PRS || '[]'); } catch (_) { bypassedPrs = []; }
             // Ignore our own guardrail checks. Their check-run names look like
             // "guardrails / issue-link / Guardrail: Issue link", so match the
             // "guardrail" token anywhere in the name (not just as a prefix).
@@ -65,6 +79,10 @@ jobs:
             }
 
             const evaluate = async (prNumber) => {
+              if (bypassedPrs.includes(prNumber)) {
+                core.info(`PR #${prNumber} is bypassed (member/override); skipping CI guardrail.`);
+                return null;
+              }
               // Fetch PR, polling until `mergeable` is computed.
               const pr = await lib.getMergeablePullRequest({ github, ...context.repo, prNumber });
               if (pr.state !== 'open') {
@@ -91,13 +109,16 @@ jobs:
                 pendingReasons.push('mergeability is still being computed by GitHub');
               }
 
-              // 2) CI check runs. A SHA accumulates a check run per (re-)run, so
-              // keep only the LATEST run per check name (highest id) — otherwise a
-              // stale failure that was later re-run green would still count. Then
-              // drop our own guardrail checks.
-              const allChecks = await github.paginate(github.rest.checks.listForRef, {
-                ...context.repo, ref: headSha, per_page: 100,
-              });
+              // 2) CI check runs. listForRef returns { total_count, check_runs };
+              // pass a map function so paginate yields the flat check_runs array.
+              // A SHA accumulates a check run per (re-)run, so keep only the LATEST
+              // run per check name (highest id) — otherwise a stale failure that was
+              // later re-run green would still count. Then drop our own guardrail checks.
+              const allChecks = await github.paginate(
+                github.rest.checks.listForRef,
+                { ...context.repo, ref: headSha, per_page: 100 },
+                (response) => response.data.check_runs,
+              );
               const latestByName = new Map();
               for (const c of allChecks) {
                 const prev = latestByName.get(c.name);
@@ -109,12 +130,19 @@ jobs:
                 (c) => c.status === 'completed' && !['success', 'neutral', 'skipped'].includes(c.conclusion),
               );
 
-              // 3) Legacy commit statuses.
+              // 3) Legacy commit statuses. Dedupe by context (keep the latest by id)
+              // so an earlier failure does not linger after a later success.
               const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
                 ...context.repo, ref: headSha,
               });
-              const failedStatuses = combined.statuses.filter((s) => s.state === 'failure' || s.state === 'error');
-              const pendingStatuses = combined.statuses.filter((s) => s.state === 'pending');
+              const latestStatusByContext = new Map();
+              for (const s of combined.statuses) {
+                const prev = latestStatusByContext.get(s.context);
+                if (!prev || s.id > prev.id) latestStatusByContext.set(s.context, s);
+              }
+              const statuses = [...latestStatusByContext.values()];
+              const failedStatuses = statuses.filter((s) => s.state === 'failure' || s.state === 'error');
+              const pendingStatuses = statuses.filter((s) => s.state === 'pending');
 
               failedChecks.forEach((c) => failures.push(`CI check not successful: \`${c.name}\` (${c.conclusion}).`));
               failedStatuses.forEach((s) => failures.push(`CI status not successful: \`${s.context}\` (${s.state}).`));

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -131,6 +131,8 @@ jobs:
                     `🚫 **CI & merge-readiness guardrail failed — this PR has been converted to draft.**`,
                     ``,
                     failures.map((f) => `- ${f}`).join('\n'),
+                    ``,
+                    lib.REVALIDATE_HINT,
                   ].join('\n'),
                 });
                 return { prNumber, result: 'failed', failures };

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: main
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -41,7 +41,10 @@ jobs:
           script: |
             const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
             const marker = 'guardrail:ci-status';
-            const SELF_PREFIX = 'Guardrail:'; // ignore our own guardrail checks
+            // Ignore our own guardrail checks. Their check-run names look like
+            // "guardrails / issue-link / Guardrail: Issue link", so match the
+            // "guardrail" token anywhere in the name (not just as a prefix).
+            const isGuardrailCheck = (name) => /guardrail/i.test(name);
 
             // Resolve the set of PRs to evaluate for this event.
             async function resolvePrNumbers() {
@@ -88,11 +91,19 @@ jobs:
                 pendingReasons.push('mergeability is still being computed by GitHub');
               }
 
-              // 2) CI check runs (excluding our own guardrail checks).
-              const checks = await github.paginate(github.rest.checks.listForRef, {
+              // 2) CI check runs. A SHA accumulates a check run per (re-)run, so
+              // keep only the LATEST run per check name (highest id) — otherwise a
+              // stale failure that was later re-run green would still count. Then
+              // drop our own guardrail checks.
+              const allChecks = await github.paginate(github.rest.checks.listForRef, {
                 ...context.repo, ref: headSha, per_page: 100,
               });
-              const others = checks.filter((c) => !c.name.startsWith(SELF_PREFIX));
+              const latestByName = new Map();
+              for (const c of allChecks) {
+                const prev = latestByName.get(c.name);
+                if (!prev || c.id > prev.id) latestByName.set(c.name, c);
+              }
+              const others = [...latestByName.values()].filter((c) => !isGuardrailCheck(c.name));
               const pendingChecks = others.filter((c) => c.status !== 'completed');
               const failedChecks = others.filter(
                 (c) => c.status === 'completed' && !['success', 'neutral', 'skipped'].includes(c.conclusion),

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -130,6 +130,8 @@ jobs:
                   body: [
                     `🚫 **CI & merge-readiness guardrail failed — this PR has been converted to draft.**`,
                     ``,
+                    `A PR can only be merged when it has no conflicts with the base branch and all CI checks pass.`,
+                    ``,
                     failures.map((f) => `- ${f}`).join('\n'),
                     ``,
                     lib.REVALIDATE_HINT,

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -33,13 +33,14 @@ jobs:
     name: "Guardrail: CI & merge readiness"
     runs-on: ubuntu-latest
     steps:
-      # Load lib.js from this reusable workflow's exact commit (job_workflow_sha)
-      # so it always matches the running version and survives branch deletion on
-      # merge. Public repo, trusted ref (never the PR head) → no token needed.
+      # Load lib.js from the collection. Pinned to the testing branch for now; at
+      # go-live switch this (and the consumer `uses:` ref) to a STABLE ref that
+      # exists after merge — `main` or a version tag — since this branch is
+      # deleted on merge. Public repo, trusted ref (never the PR head) → no token.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: ${{ github.job_workflow_sha }}
+          ref: feature/pr-guardrails
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -33,12 +33,13 @@ jobs:
     name: "Guardrail: CI & merge readiness"
     runs-on: ubuntu-latest
     steps:
-      # Checks out this (trusted, public) collection repo to load lib.js
-      # (never the PR head). Public repo → no token needed for checkout.
+      # Load lib.js from this reusable workflow's exact commit (job_workflow_sha)
+      # so it always matches the running version and survives branch deletion on
+      # merge. Public repo, trusted ref (never the PR head) → no token needed.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: ${{ github.job_workflow_sha }}
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -33,14 +33,13 @@ jobs:
     name: "Guardrail: CI & merge readiness"
     runs-on: ubuntu-latest
     steps:
-      # Load lib.js from the collection. Pinned to the testing branch for now; at
-      # go-live switch this (and the consumer `uses:` ref) to a STABLE ref that
-      # exists after merge — `main` or a version tag — since this branch is
-      # deleted on merge. Public repo, trusted ref (never the PR head) → no token.
+      # Load lib.js from this collection on `main` (stable ref). Changing logic is
+      # just edit + push to main — no ref change needed here. Public repo, trusted
+      # ref (never the PR head) → no token needed for checkout.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: main
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -119,10 +119,7 @@ jobs:
                   body: [
                     `🚫 **CI & merge-readiness guardrail failed — this PR has been converted to draft.**`,
                     ``,
-                    `Problems on \`${headSha.slice(0, 7)}\`:`,
                     failures.map((f) => `- ${f}`).join('\n'),
-                    ``,
-                    lib.REVALIDATE_HINT,
                   ].join('\n'),
                 });
                 return { prNumber, result: 'failed', failures };
@@ -133,10 +130,8 @@ jobs:
                 return { prNumber, result: 'pending', pendingReasons };
               }
 
-              await lib.upsertComment({
-                github, context, issueNumber: prNumber, marker,
-                body: `✅ **CI & merge-readiness guardrail passed** — no conflicts and all CI checks succeeded on \`${headSha.slice(0, 7)}\`.`,
-              });
+              // Passed: no comment, but clear any prior failure comment.
+              await lib.deleteMarkerComment({ github, context, issueNumber: prNumber, marker });
               return { prNumber, result: 'passed' };
             };
 

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -1,0 +1,155 @@
+name: "Reusable Guardrail: CI & merge readiness"
+
+# Enforcing guardrail. Requires that the PR is mergeable (no conflicts with the
+# base branch) AND that all CI checks/statuses on the head commit succeed. While
+# checks or the mergeability computation are still in progress the guardrail stays
+# neutral (it does not draft). On a definitive failure the PR is converted to
+# draft with an explanatory comment. The guardrail ignores its own "Guardrail:"
+# checks to avoid self-deadlock. Runs on PR events and on check_suite completion.
+#
+# Called by parent-pr-guardrails.yml in the caller's event context.
+
+on:
+  workflow_call:
+    secrets:
+      CI_GUARD_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  ci:
+    name: "Guardrail: CI & merge readiness"
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out this (trusted, public) collection repo to load lib.js
+      # (never the PR head). Public repo → no token needed for checkout.
+      - uses: actions/checkout@v4
+        with:
+          repository: pimcore/workflows-collection-public
+          ref: feature/pr-guardrails
+          path: _central
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CI_GUARD_TOKEN }}
+          script: |
+            const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
+            const marker = 'guardrail:ci-status';
+            const SELF_PREFIX = 'Guardrail:'; // ignore our own guardrail checks
+
+            // Resolve the set of PRs to evaluate for this event.
+            async function resolvePrNumbers() {
+              if (context.payload.pull_request) return [context.payload.pull_request.number];
+              if (context.eventName === 'check_suite') {
+                const cs = context.payload.check_suite;
+                let prs = cs.pull_requests || [];
+                if (prs.length === 0) {
+                  const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                    ...context.repo,
+                    commit_sha: cs.head_sha,
+                  });
+                  prs = data;
+                }
+                return prs.map((p) => p.number);
+              }
+              return [];
+            }
+
+            const evaluate = async (prNumber) => {
+              // Fetch PR, polling until `mergeable` is computed.
+              const pr = await lib.getMergeablePullRequest({ github, ...context.repo, prNumber });
+              if (pr.state !== 'open') {
+                core.info(`PR #${prNumber} is ${pr.state}; skipping.`);
+                return null;
+              }
+              if (pr.draft) {
+                core.info(`PR #${prNumber} is a draft; skipping (work in progress).`);
+                return null;
+              }
+              const headSha = pr.head.sha;
+
+              const failures = [];
+              const pendingReasons = [];
+
+              // 1) Mergeability / conflicts.
+              if (pr.mergeable === false) {
+                if (pr.mergeable_state === 'dirty') {
+                  failures.push(`PR has **merge conflicts** with \`${pr.base.ref}\` — rebase or merge \`${pr.base.ref}\` and resolve the conflicts.`);
+                } else {
+                  failures.push(`PR is not mergeable (state: \`${pr.mergeable_state}\`).`);
+                }
+              } else if (pr.mergeable === null) {
+                pendingReasons.push('mergeability is still being computed by GitHub');
+              }
+
+              // 2) CI check runs (excluding our own guardrail checks).
+              const checks = await github.paginate(github.rest.checks.listForRef, {
+                ...context.repo, ref: headSha, per_page: 100,
+              });
+              const others = checks.filter((c) => !c.name.startsWith(SELF_PREFIX));
+              const pendingChecks = others.filter((c) => c.status !== 'completed');
+              const failedChecks = others.filter(
+                (c) => c.status === 'completed' && !['success', 'neutral', 'skipped'].includes(c.conclusion),
+              );
+
+              // 3) Legacy commit statuses.
+              const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+                ...context.repo, ref: headSha,
+              });
+              const failedStatuses = combined.statuses.filter((s) => s.state === 'failure' || s.state === 'error');
+              const pendingStatuses = combined.statuses.filter((s) => s.state === 'pending');
+
+              failedChecks.forEach((c) => failures.push(`CI check not successful: \`${c.name}\` (${c.conclusion}).`));
+              failedStatuses.forEach((s) => failures.push(`CI status not successful: \`${s.context}\` (${s.state}).`));
+              pendingChecks.forEach((c) => pendingReasons.push(`check \`${c.name}\` still running`));
+              pendingStatuses.forEach((s) => pendingReasons.push(`status \`${s.context}\` still pending`));
+
+              if (failures.length > 0) {
+                if (!pr.draft) {
+                  await lib.convertToDraft({ github, pullRequestNodeId: pr.node_id });
+                }
+                await lib.upsertComment({
+                  github, context, issueNumber: prNumber, marker,
+                  body: [
+                    `🚫 **CI & merge-readiness guardrail failed — this PR has been converted to draft.**`,
+                    ``,
+                    `Problems on \`${headSha.slice(0, 7)}\`:`,
+                    failures.map((f) => `- ${f}`).join('\n'),
+                    ``,
+                    lib.REVALIDATE_HINT,
+                  ].join('\n'),
+                });
+                return { prNumber, result: 'failed', failures };
+              }
+
+              if (pendingReasons.length > 0) {
+                core.info(`PR #${prNumber}: not yet decisive (${pendingReasons.join('; ')}); staying neutral.`);
+                return { prNumber, result: 'pending', pendingReasons };
+              }
+
+              await lib.upsertComment({
+                github, context, issueNumber: prNumber, marker,
+                body: `✅ **CI & merge-readiness guardrail passed** — no conflicts and all CI checks succeeded on \`${headSha.slice(0, 7)}\`.`,
+              });
+              return { prNumber, result: 'passed' };
+            };
+
+            const prNumbers = await resolvePrNumbers();
+            if (prNumbers.length === 0) {
+              core.info('No pull request associated with this event; nothing to do.');
+              return;
+            }
+
+            const results = [];
+            for (const n of prNumbers) {
+              results.push(await evaluate(n));
+            }
+            if (results.some((r) => r && r.result === 'failed')) {
+              core.setFailed('CI & merge-readiness guardrail failed for at least one PR.');
+            }

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: main
+          ref: feature/pr-guardrails
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -40,7 +40,6 @@ jobs:
             const marker = 'guardrail:issue-link';
 
             const pr = context.payload.pull_request;
-            const author = pr.user.login;
             const issueNumber = pr.number;
 
             // Parse closing-keyword references from title + body (untrusted data).
@@ -51,20 +50,16 @@ jobs:
             let validCount = 0;
 
             if (refs.length === 0) {
-              problems.push(
-                `No closing-keyword issue reference found. Add one, e.g. \`Fixes ${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}#123\`.`,
-              );
+              problems.push(`No issue in \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` is linked.`);
             }
 
             for (const ref of refs) {
-              // Every keyword reference must target the platform-version repo.
+              // Every reference must target the platform-version repo.
               if (
                 ref.owner.toLowerCase() !== lib.ISSUE_REPO_OWNER.toLowerCase() ||
                 ref.repo.toLowerCase() !== lib.ISSUE_REPO_NAME.toLowerCase()
               ) {
-                problems.push(
-                  `\`${ref.raw}\` references \`${ref.owner}/${ref.repo}\`, but only \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` is accepted.`,
-                );
+                problems.push(`\`${ref.raw}\` does not reference \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\`.`);
                 continue;
               }
               const res = await lib.validateIssue({ github, owner: ref.owner, repo: ref.repo, number: ref.number });
@@ -79,14 +74,11 @@ jobs:
 
             if (passed) {
               core.info(`Issue-link guardrail passed (${validCount} valid link(s)).`);
-              await lib.upsertComment({
-                github, context, issueNumber, marker,
-                body: `✅ **Issue-link guardrail passed** — ${validCount} valid issue link(s) to \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\`.`,
-              });
+              await lib.deleteMarkerComment({ github, context, issueNumber, marker });
               return;
             }
 
-            // FAIL → convert to draft + explain.
+            // FAIL → convert to draft + comment the simple reason(s) + docs link.
             if (!pr.draft) {
               await lib.convertToDraft({ github, pullRequestNodeId: pr.node_id });
             }
@@ -96,14 +88,9 @@ jobs:
               body: [
                 `🚫 **Issue-link guardrail failed — this PR has been converted to draft.**`,
                 ``,
-                `@${author} is not a member of \`${lib.ORG}/${lib.TEAM_SLUG}\`, so this PR must link a valid issue in \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` using a supported closing keyword, and every closing-keyword reference must be valid.`,
-                ``,
-                `**Problems found:**`,
                 problemList,
                 ``,
-                `**Supported keywords:** ${lib.CLOSING_KEYWORDS.join(', ')}`,
-                ``,
-                lib.REVALIDATE_HINT,
+                `https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests`,
               ].join('\n'),
             });
             core.setFailed('Issue-link guardrail failed.');

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -24,14 +24,13 @@ jobs:
     name: "Guardrail: Issue link"
     runs-on: ubuntu-latest
     steps:
-      # Load lib.js from the collection. Pinned to the testing branch for now; at
-      # go-live switch this (and the consumer `uses:` ref) to a STABLE ref that
-      # exists after merge — `main` or a version tag — since this branch is
-      # deleted on merge. Public repo, trusted ref (never the PR head) → no token.
+      # Load lib.js from this collection on `main` (stable ref). Changing logic is
+      # just edit + push to main — no ref change needed here. Public repo, trusted
+      # ref (never the PR head) → no token needed for checkout.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: main
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -24,13 +24,14 @@ jobs:
     name: "Guardrail: Issue link"
     runs-on: ubuntu-latest
     steps:
-      # Load lib.js from this reusable workflow's exact commit (job_workflow_sha)
-      # so it always matches the running version and survives branch deletion on
-      # merge. Public repo, trusted ref (never the PR head) → no token needed.
+      # Load lib.js from the collection. Pinned to the testing branch for now; at
+      # go-live switch this (and the consumer `uses:` ref) to a STABLE ref that
+      # exists after merge — `main` or a version tag — since this branch is
+      # deleted on merge. Public repo, trusted ref (never the PR head) → no token.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: ${{ github.job_workflow_sha }}
+          ref: feature/pr-guardrails
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -88,6 +88,8 @@ jobs:
               body: [
                 `🚫 **Issue-link guardrail failed — this PR has been converted to draft.**`,
                 ``,
+                `Every PR must reference a tracking issue in \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` so the change stays traceable.`,
+                ``,
                 problemList,
                 ``,
                 `Add the link with a keyword in the **PR description** (not in a comment): https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests`,

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -1,0 +1,109 @@
+name: "Reusable Guardrail: Issue link"
+
+# Enforcing guardrail. The orchestrator only invokes this for non-draft PRs whose
+# author is NOT a Dev-Team member, so there is no membership check here. The PR
+# must link at least one valid issue in pimcore/platform-version using a
+# supported closing keyword, AND every closing-keyword reference must be valid.
+# On failure the PR is converted to draft with an explanatory comment.
+#
+# Called by parent-pr-guardrails.yml in the caller's pull_request_target context.
+
+on:
+  workflow_call:
+    secrets:
+      ISSUE_LINK_GUARD_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  issue-link:
+    name: "Guardrail: Issue link"
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out this (trusted, public) collection repo to load lib.js
+      # (never the PR head). Public repo → no token needed for checkout.
+      - uses: actions/checkout@v4
+        with:
+          repository: pimcore/workflows-collection-public
+          ref: feature/pr-guardrails
+          path: _central
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
+          script: |
+            const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
+            const marker = 'guardrail:issue-link';
+
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const issueNumber = pr.number;
+
+            // Parse closing-keyword references from title + body (untrusted data).
+            const text = `${pr.title}\n\n${pr.body || ''}`;
+            const refs = lib.parseIssueReferences(text);
+
+            const problems = [];
+            let validCount = 0;
+
+            if (refs.length === 0) {
+              problems.push(
+                `No closing-keyword issue reference found. Add one, e.g. \`Fixes ${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}#123\`.`,
+              );
+            }
+
+            for (const ref of refs) {
+              // Every keyword reference must target the platform-version repo.
+              if (
+                ref.owner.toLowerCase() !== lib.ISSUE_REPO_OWNER.toLowerCase() ||
+                ref.repo.toLowerCase() !== lib.ISSUE_REPO_NAME.toLowerCase()
+              ) {
+                problems.push(
+                  `\`${ref.raw}\` references \`${ref.owner}/${ref.repo}\`, but only \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` is accepted.`,
+                );
+                continue;
+              }
+              const res = await lib.validateIssue({ github, owner: ref.owner, repo: ref.repo, number: ref.number });
+              if (res.valid) {
+                validCount++;
+              } else {
+                problems.push(`\`${ref.raw}\` is not valid: ${res.reason}.`);
+              }
+            }
+
+            const passed = refs.length > 0 && problems.length === 0 && validCount > 0;
+
+            if (passed) {
+              core.info(`Issue-link guardrail passed (${validCount} valid link(s)).`);
+              await lib.upsertComment({
+                github, context, issueNumber, marker,
+                body: `✅ **Issue-link guardrail passed** — ${validCount} valid issue link(s) to \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\`.`,
+              });
+              return;
+            }
+
+            // FAIL → convert to draft + explain.
+            if (!pr.draft) {
+              await lib.convertToDraft({ github, pullRequestNodeId: pr.node_id });
+            }
+            const problemList = problems.map((p) => `- ${p}`).join('\n');
+            await lib.upsertComment({
+              github, context, issueNumber, marker,
+              body: [
+                `🚫 **Issue-link guardrail failed — this PR has been converted to draft.**`,
+                ``,
+                `@${author} is not a member of \`${lib.ORG}/${lib.TEAM_SLUG}\`, so this PR must link a valid issue in \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` using a supported closing keyword, and every closing-keyword reference must be valid.`,
+                ``,
+                `**Problems found:**`,
+                problemList,
+                ``,
+                `**Supported keywords:** ${lib.CLOSING_KEYWORDS.join(', ')}`,
+                ``,
+                lib.REVALIDATE_HINT,
+              ].join('\n'),
+            });
+            core.setFailed('Issue-link guardrail failed.');

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: main
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -24,12 +24,13 @@ jobs:
     name: "Guardrail: Issue link"
     runs-on: ubuntu-latest
     steps:
-      # Checks out this (trusted, public) collection repo to load lib.js
-      # (never the PR head). Public repo → no token needed for checkout.
+      # Load lib.js from this reusable workflow's exact commit (job_workflow_sha)
+      # so it always matches the running version and survives branch deletion on
+      # merge. Public repo, trusted ref (never the PR head) → no token needed.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: ${{ github.job_workflow_sha }}
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: main
+          ref: feature/pr-guardrails
           path: _central
 
       - uses: actions/github-script@v7

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -90,7 +90,9 @@ jobs:
                 ``,
                 problemList,
                 ``,
-                `https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests`,
+                `Add the link with a keyword in the **PR description** (not in a comment): https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests`,
+                ``,
+                lib.REVALIDATE_HINT,
               ].join('\n'),
             });
             core.setFailed('Issue-link guardrail failed.');

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -97,7 +97,11 @@ jobs:
                   && await lib.isDevTeamMember({ github, username: actor })) {
                 bypass = true;
                 await lib.addLabel({ github, context, issueNumber: pr.number, label: OVERRIDE_LABEL });
-                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed.`);
+                // Override clears any guardrail failure comments left by earlier runs.
+                for (const m of ['guardrail:issue-link', 'guardrail:ci-status']) {
+                  await lib.deleteMarkerComment({ github, context, issueNumber: pr.number, marker: m });
+                }
+                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed, failure comments cleared.`);
               }
 
               core.info(`PR #${pr.number}: bypass=${bypass}`);

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -19,8 +19,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
+  pull-requests: read
 
 jobs:
   membership:
@@ -43,7 +42,6 @@ jobs:
           github-token: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}
           script: |
             const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
-            const marker = 'guardrail:membership';
 
             // Resolve the PR(s) for this event. On pull_request_target there is
             // exactly one; on check_suite resolve from the payload / commit.
@@ -78,26 +76,13 @@ jobs:
 
             // is_member is 'true' only if EVERY associated PR author is a member
             // (so if any non-member PR is in scope, the other guardrails still run).
+            // Membership posts no comment (only failed guardrails comment); it
+            // just resolves whether every PR author is a member.
             let allMembers = true;
             for (const pr of prs) {
               const author = pr.user.login;
               const member = await lib.isDevTeamMember({ github, username: author });
               if (!member) allMembers = false;
               core.info(`${author} (PR #${pr.number}): member=${member}`);
-
-              // Comment only on the direct PR event (avoids noise on check_suite).
-              if (context.eventName === 'pull_request_target') {
-                if (member) {
-                  await lib.upsertComment({
-                    github, context, issueNumber: pr.number, marker,
-                    body: `✅ **Dev-Team membership guardrail passed** — @${author} is a member of \`${lib.ORG}/${lib.TEAM_SLUG}\`. This PR is exempt from all other guardrails.`,
-                  });
-                } else {
-                  await lib.upsertComment({
-                    github, context, issueNumber: pr.number, marker,
-                    body: `ℹ️ @${author} is **not** a member of \`${lib.ORG}/${lib.TEAM_SLUG}\`, so the remaining guardrails apply: link a valid issue in \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` and pass CI.`,
-                  });
-                }
-              }
             }
             core.setOutput('is_member', allMembers ? 'true' : 'false');

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -1,11 +1,14 @@
 name: "Reusable Guardrail: Dev-Team membership"
 
-# Fast-path guardrail. If the PR author is a member of the "Dev-Team" group the
-# PR is accepted and exempt from the linked-issue requirement (the orchestrator
-# uses the `is_member` output to skip the issue-link stage). Non-members are NOT
-# blocked here, so this workflow never converts a PR to draft and always succeeds.
+# Fast-path / bypass guardrail. Emits `bypass=true` (so the orchestrator skips
+# the issue-link and CI guardrails) when ANY of:
+#   - the PR author is a Dev-Team member, or
+#   - the PR carries the override label, or
+#   - a Dev-Team member pressed "Ready for review" on the PR (manual override) —
+#     in which case the override label is added so later runs keep bypassing.
+# This workflow never converts a PR to draft and always succeeds.
 #
-# Called by parent-pr-guardrails.yml in the caller's pull_request_target context.
+# Called by parent-pr-guardrails.yml in the caller's event context.
 
 on:
   workflow_call:
@@ -13,20 +16,21 @@ on:
       MEMBERSHIP_GUARD_TOKEN:
         required: true
     outputs:
-      is_member:
-        description: "true when the PR author is an active Dev-Team member"
-        value: ${{ jobs.membership.outputs.is_member }}
+      bypass:
+        description: "true when guardrails should be skipped (member author, override label, or member override)"
+        value: ${{ jobs.membership.outputs.bypass }}
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
+  issues: write
 
 jobs:
   membership:
     name: "Guardrail: Dev-Team membership"
     runs-on: ubuntu-latest
     outputs:
-      is_member: ${{ steps.check.outputs.is_member }}
+      bypass: ${{ steps.check.outputs.bypass }}
     steps:
       # Checks out this (trusted, public) collection repo to load lib.js
       # (never the PR head). Public repo → no token needed for checkout.
@@ -42,6 +46,7 @@ jobs:
           github-token: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}
           script: |
             const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
+            const OVERRIDE_LABEL = 'guardrails:override';
 
             // Resolve the PR(s) for this event. On pull_request_target there is
             // exactly one; on check_suite resolve from the payload / commit.
@@ -56,7 +61,7 @@ jobs:
                   });
                   prs = data;
                 }
-                // check_suite PR entries lack `user`; fetch the full PR for the author.
+                // check_suite PR entries are minimal; fetch the full PR.
                 const full = [];
                 for (const p of prs) {
                   const { data } = await github.rest.pulls.get({ ...context.repo, pull_number: p.number });
@@ -69,20 +74,33 @@ jobs:
 
             const prs = await resolvePrs();
             if (prs.length === 0) {
-              core.info('No pull request for this event; treating as non-member.');
-              core.setOutput('is_member', 'false');
+              core.info('No pull request for this event; not bypassing.');
+              core.setOutput('bypass', 'false');
               return;
             }
 
-            // is_member is 'true' only if EVERY associated PR author is a member
-            // (so if any non-member PR is in scope, the other guardrails still run).
-            // Membership posts no comment (only failed guardrails comment); it
-            // just resolves whether every PR author is a member.
-            let allMembers = true;
+            // Manual override: a Dev-Team member pressing "Ready for review" on a
+            // PR. The override is persisted as a label so later events (e.g.
+            // check_suite) keep bypassing instead of re-drafting.
+            const isReadyForReview = context.eventName === 'pull_request_target'
+              && context.payload.action === 'ready_for_review';
+            const actor = context.payload.sender && context.payload.sender.login;
+
+            // bypass=true only if EVERY associated PR qualifies (so any still-gated
+            // PR keeps the other guardrails running). Membership posts no comment.
+            let allBypass = true;
             for (const pr of prs) {
-              const author = pr.user.login;
-              const member = await lib.isDevTeamMember({ github, username: author });
-              if (!member) allMembers = false;
-              core.info(`${author} (PR #${pr.number}): member=${member}`);
+              const hasLabel = (pr.labels || []).some((l) => l.name === OVERRIDE_LABEL);
+              let bypass = hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+
+              if (!bypass && isReadyForReview && actor
+                  && await lib.isDevTeamMember({ github, username: actor })) {
+                bypass = true;
+                await lib.addLabel({ github, context, issueNumber: pr.number, label: OVERRIDE_LABEL });
+                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed.`);
+              }
+
+              core.info(`PR #${pr.number}: bypass=${bypass}`);
+              if (!bypass) allBypass = false;
             }
-            core.setOutput('is_member', allMembers ? 'true' : 'false');
+            core.setOutput('bypass', allBypass ? 'true' : 'false');

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -89,10 +89,11 @@ jobs:
 
             // A Dev-Team member converting the PR back to draft retracts the
             // override: remove the label so the guardrails re-apply next time it
-            // is made ready. Gated to a member actor so the guardrails' own
-            // draft-conversion (by the bot token) never clears the label.
+            // is made ready. The guard service account is itself a Dev-Team
+            // member, so its own draft-conversions (when a guardrail drafts a PR)
+            // are explicitly ignored — only a human member retracts.
             if (context.eventName === 'pull_request_target' && action === 'converted_to_draft') {
-              if (actor && await lib.isDevTeamMember({ github, username: actor })) {
+              if (actor && actor !== lib.GUARD_BOT && await lib.isDevTeamMember({ github, username: actor })) {
                 for (const pr of prs) {
                   await lib.removeLabel({ github, context, issueNumber: pr.number, label: OVERRIDE_LABEL });
                   core.info(`@${actor} (Dev-Team) converted PR #${pr.number} to draft — override label removed.`);

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -36,13 +36,14 @@ jobs:
       bypass: ${{ steps.check.outputs.bypass }}
       bypassed_prs: ${{ steps.check.outputs.bypassed_prs }}
     steps:
-      # Load lib.js from this reusable workflow's exact commit (job_workflow_sha)
-      # so it always matches the running version and survives branch deletion on
-      # merge. Public repo, trusted ref (never the PR head) → no token needed.
+      # Load lib.js from the collection. Pinned to the testing branch for now; at
+      # go-live switch this (and the consumer `uses:` ref) to a STABLE ref that
+      # exists after merge — `main` or a version tag — since this branch is
+      # deleted on merge. Public repo, trusted ref (never the PR head) → no token.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: ${{ github.job_workflow_sha }}
+          ref: feature/pr-guardrails
           path: _central
 
       - id: check

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: main
           path: _central
 
       - id: check

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -1,0 +1,103 @@
+name: "Reusable Guardrail: Dev-Team membership"
+
+# Fast-path guardrail. If the PR author is a member of the "Dev-Team" group the
+# PR is accepted and exempt from the linked-issue requirement (the orchestrator
+# uses the `is_member` output to skip the issue-link stage). Non-members are NOT
+# blocked here, so this workflow never converts a PR to draft and always succeeds.
+#
+# Called by parent-pr-guardrails.yml in the caller's pull_request_target context.
+
+on:
+  workflow_call:
+    secrets:
+      MEMBERSHIP_GUARD_TOKEN:
+        required: true
+    outputs:
+      is_member:
+        description: "true when the PR author is an active Dev-Team member"
+        value: ${{ jobs.membership.outputs.is_member }}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  membership:
+    name: "Guardrail: Dev-Team membership"
+    runs-on: ubuntu-latest
+    outputs:
+      is_member: ${{ steps.check.outputs.is_member }}
+    steps:
+      # Checks out this (trusted, public) collection repo to load lib.js
+      # (never the PR head). Public repo → no token needed for checkout.
+      - uses: actions/checkout@v4
+        with:
+          repository: pimcore/workflows-collection-public
+          ref: feature/pr-guardrails
+          path: _central
+
+      - id: check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.MEMBERSHIP_GUARD_TOKEN }}
+          script: |
+            const lib = require(`${process.env.GITHUB_WORKSPACE}/_central/scripts/guardrails/lib.js`);
+            const marker = 'guardrail:membership';
+
+            // Resolve the PR(s) for this event. On pull_request_target there is
+            // exactly one; on check_suite resolve from the payload / commit.
+            async function resolvePrs() {
+              if (context.payload.pull_request) return [context.payload.pull_request];
+              if (context.eventName === 'check_suite') {
+                const cs = context.payload.check_suite;
+                let prs = cs.pull_requests || [];
+                if (prs.length === 0) {
+                  const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                    ...context.repo, commit_sha: cs.head_sha,
+                  });
+                  prs = data;
+                }
+                // check_suite PR entries lack `user`; fetch the full PR for the author.
+                const full = [];
+                for (const p of prs) {
+                  const { data } = await github.rest.pulls.get({ ...context.repo, pull_number: p.number });
+                  full.push(data);
+                }
+                return full;
+              }
+              return [];
+            }
+
+            const prs = await resolvePrs();
+            if (prs.length === 0) {
+              core.info('No pull request for this event; treating as non-member.');
+              core.setOutput('is_member', 'false');
+              return;
+            }
+
+            // is_member is 'true' only if EVERY associated PR author is a member
+            // (so if any non-member PR is in scope, the other guardrails still run).
+            let allMembers = true;
+            for (const pr of prs) {
+              const author = pr.user.login;
+              const member = await lib.isDevTeamMember({ github, username: author });
+              if (!member) allMembers = false;
+              core.info(`${author} (PR #${pr.number}): member=${member}`);
+
+              // Comment only on the direct PR event (avoids noise on check_suite).
+              if (context.eventName === 'pull_request_target') {
+                if (member) {
+                  await lib.upsertComment({
+                    github, context, issueNumber: pr.number, marker,
+                    body: `✅ **Dev-Team membership guardrail passed** — @${author} is a member of \`${lib.ORG}/${lib.TEAM_SLUG}\`. This PR is exempt from all other guardrails.`,
+                  });
+                } else {
+                  await lib.upsertComment({
+                    github, context, issueNumber: pr.number, marker,
+                    body: `ℹ️ @${author} is **not** a member of \`${lib.ORG}/${lib.TEAM_SLUG}\`, so the remaining guardrails apply: link a valid issue in \`${lib.ISSUE_REPO_OWNER}/${lib.ISSUE_REPO_NAME}\` and pass CI.`,
+                  });
+                }
+              }
+            }
+            core.setOutput('is_member', allMembers ? 'true' : 'false');

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -17,8 +17,11 @@ on:
         required: true
     outputs:
       bypass:
-        description: "true when guardrails should be skipped (member author, override label, or member override)"
+        description: "true when ALL associated PRs should be skipped (member author, override label, or member override)"
         value: ${{ jobs.membership.outputs.bypass }}
+      bypassed_prs:
+        description: "JSON array of the PR numbers that individually qualify for bypass"
+        value: ${{ jobs.membership.outputs.bypassed_prs }}
 
 permissions:
   contents: read
@@ -31,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       bypass: ${{ steps.check.outputs.bypass }}
+      bypassed_prs: ${{ steps.check.outputs.bypassed_prs }}
     steps:
       # Checks out this (trusted, public) collection repo to load lib.js
       # (never the PR head). Public repo → no token needed for checkout.
@@ -76,6 +80,7 @@ jobs:
             if (prs.length === 0) {
               core.info('No pull request for this event; not bypassing.');
               core.setOutput('bypass', 'false');
+              core.setOutput('bypassed_prs', '[]');
               return;
             }
 
@@ -94,6 +99,7 @@ jobs:
                 }
               }
               core.setOutput('bypass', 'false');
+              core.setOutput('bypassed_prs', '[]');
               return;
             }
 
@@ -103,9 +109,11 @@ jobs:
             const isReadyForReview = context.eventName === 'pull_request_target'
               && action === 'ready_for_review';
 
-            // bypass=true only if EVERY associated PR qualifies (so any still-gated
-            // PR keeps the other guardrails running). Membership posts no comment.
+            // Compute bypass PER PR. `bypassed_prs` lets later guardrails skip the
+            // exact PRs that qualify (important when a check_suite is shared by
+            // several PRs); `bypass` (all qualify) drives the orchestrator's gate.
             let allBypass = true;
+            const bypassedPrs = [];
             for (const pr of prs) {
               const hasLabel = (pr.labels || []).some((l) => l.name === OVERRIDE_LABEL);
               let bypass = hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
@@ -122,6 +130,7 @@ jobs:
               }
 
               core.info(`PR #${pr.number}: bypass=${bypass}`);
-              if (!bypass) allBypass = false;
+              if (bypass) bypassedPrs.push(pr.number); else allBypass = false;
             }
             core.setOutput('bypass', allBypass ? 'true' : 'false');
+            core.setOutput('bypassed_prs', JSON.stringify(bypassedPrs));

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -36,14 +36,13 @@ jobs:
       bypass: ${{ steps.check.outputs.bypass }}
       bypassed_prs: ${{ steps.check.outputs.bypassed_prs }}
     steps:
-      # Load lib.js from the collection. Pinned to the testing branch for now; at
-      # go-live switch this (and the consumer `uses:` ref) to a STABLE ref that
-      # exists after merge — `main` or a version tag — since this branch is
-      # deleted on merge. Public repo, trusted ref (never the PR head) → no token.
+      # Load lib.js from this collection on `main` (stable ref). Changing logic is
+      # just edit + push to main — no ref change needed here. Public repo, trusted
+      # ref (never the PR head) → no token needed for checkout.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: main
           path: _central
 
       - id: check

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -79,12 +79,29 @@ jobs:
               return;
             }
 
+            const action = context.payload.action;
+            const actor = context.payload.sender && context.payload.sender.login;
+
+            // A Dev-Team member converting the PR back to draft retracts the
+            // override: remove the label so the guardrails re-apply next time it
+            // is made ready. Gated to a member actor so the guardrails' own
+            // draft-conversion (by the bot token) never clears the label.
+            if (context.eventName === 'pull_request_target' && action === 'converted_to_draft') {
+              if (actor && await lib.isDevTeamMember({ github, username: actor })) {
+                for (const pr of prs) {
+                  await lib.removeLabel({ github, context, issueNumber: pr.number, label: OVERRIDE_LABEL });
+                  core.info(`@${actor} (Dev-Team) converted PR #${pr.number} to draft — override label removed.`);
+                }
+              }
+              core.setOutput('bypass', 'false');
+              return;
+            }
+
             // Manual override: a Dev-Team member pressing "Ready for review" on a
             // PR. The override is persisted as a label so later events (e.g.
             // check_suite) keep bypassing instead of re-drafting.
             const isReadyForReview = context.eventName === 'pull_request_target'
-              && context.payload.action === 'ready_for_review';
-            const actor = context.payload.sender && context.payload.sender.login;
+              && action === 'ready_for_review';
 
             // bypass=true only if EVERY associated PR qualifies (so any still-gated
             // PR keeps the other guardrails running). Membership posts no comment.

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -36,12 +36,13 @@ jobs:
       bypass: ${{ steps.check.outputs.bypass }}
       bypassed_prs: ${{ steps.check.outputs.bypassed_prs }}
     steps:
-      # Checks out this (trusted, public) collection repo to load lib.js
-      # (never the PR head). Public repo → no token needed for checkout.
+      # Load lib.js from this reusable workflow's exact commit (job_workflow_sha)
+      # so it always matches the running version and survives branch deletion on
+      # merge. Public repo, trusted ref (never the PR head) → no token needed.
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: feature/pr-guardrails
+          ref: ${{ github.job_workflow_sha }}
           path: _central
 
       - id: check

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: main
+          ref: feature/pr-guardrails
           path: _central
 
       - id: check

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -39,11 +39,14 @@ added/removed — that only changes this repo (+ org secrets).
 
 ## Pipeline
 
+Comments are posted **only when a guardrail fails**. On a pass (or when a member
+is exempt) no comment is created, and any prior failure comment is removed.
+
 | Stage | Runs when | On failure |
 |-------|-----------|------------|
-| membership | all events (resolves author on PR + `check_suite`) | never drafts; emits `is_member` |
-| issue-link | non-draft PR events **and** author is not a Dev-Team member | draft + comment |
-| ci | all events (PR + `check_suite`) **and** author is not a Dev-Team member | draft + comment |
+| membership | all events (resolves author on PR + `check_suite`) | never drafts, never comments; emits `is_member` |
+| issue-link | non-draft PR events **and** author is not a Dev-Team member | draft + comment (reason + docs link) |
+| ci | all events (PR + `check_suite`) **and** author is not a Dev-Team member | draft + comment (reason) |
 
 - **Members are fully exempt**: if the PR author is a Dev-Team member,
   `is_member=true` and the orchestrator **skips every other guardrail** (both
@@ -58,8 +61,10 @@ added/removed — that only changes this repo (+ org secrets).
 ## Revalidation
 
 On failure a guardrail converts the PR to **draft** and posts a single marker
-comment (updated in place on re-runs). The PR author fixes the issue and clicks
-**Ready for review**; the `ready_for_review` event re-fires the pipeline.
+comment with the reason (issue-link also links the GitHub keywords docs). The PR
+author fixes the issue and clicks **Ready for review**; the `ready_for_review`
+event re-fires the pipeline. When the guardrail then passes, its failure comment
+is removed.
 
 ## Tokens & required settings
 
@@ -73,7 +78,7 @@ used for `CI_GUARD_TOKEN` because it has no *Checks* permission.
 
 | Token | GitHub App permissions (by target repo / org) | Classic PAT scopes | Used for |
 |-------|-----------------------------------------------|--------------------|----------|
-| `MEMBERSHIP_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**; `pimcore` org → Members: **Read** | `repo` (or `public_repo`) + `read:org` | Team-membership lookup; read PR(s) (incl. resolving from `check_suite`); post membership comment. Never drafts. |
+| `MEMBERSHIP_GUARD_TOKEN` | consumer repo → Pull requests: **Read**; `pimcore` org → Members: **Read** | `repo` (or `public_repo`) + `read:org` | Team-membership lookup; read PR(s) (incl. resolving from `check_suite`). Never drafts, never comments. |
 | `ISSUE_LINK_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**; `pimcore/platform-version` → Issues: **Read** | `repo` (+ read on `platform-version` if private) | Validate linked issues exist; convert PR to draft; comment. No org permission. |
 | `CI_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**, Checks: **Read**, Commit statuses: **Read**, Contents: **Read** | `repo` | Read PR + mergeability; list checks & statuses; convert PR to draft; comment. No org permission. |
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -97,10 +97,16 @@ No consumer repo is touched.
 
 ## Configuration
 
-`lib.js` reads `GUARD_ORG`, `GUARD_TEAM_SLUG`, `GUARD_ISSUE_OWNER`,
-`GUARD_ISSUE_REPO` from the environment (defaults `pimcore` / `dev-team` /
-`pimcore/platform-version`). Confirm the **team slug** — the slug of "Dev-Team"
-is assumed to be `dev-team`.
+`lib.js` reads these from the environment:
+
+- `GUARD_ORG` (default `pimcore`)
+- `GUARD_TEAM_SLUG` (default `dev-team`) — confirm the slug of "Dev-Team"
+- `GUARD_ISSUE_OWNER` / `GUARD_ISSUE_REPO` (default `pimcore` / `platform-version`)
+- `GUARD_BOT_LOGIN` (default `pimcore-deployments`) — the service account the
+  guardrails act as. Used to (a) ignore the bot's own draft-conversions during
+  override retraction, and (b) restrict marker-comment management to the bot's
+  own comments. **Set this if your guardrail tokens belong to a different
+  account**, or retraction and comment cleanup will misbehave.
 
 ## Security
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -85,32 +85,6 @@ guardrails apply again the next time the PR is made ready. Only a member's
 draft-conversion clears it — the guardrails' own drafting (by the bot token)
 does not.
 
-## Tokens & required settings
-
-Org-level secrets shared to consumer repos, reached via `secrets: inherit`:
-`MEMBERSHIP_GUARD_TOKEN`, `ISSUE_LINK_GUARD_TOKEN`, `CI_GUARD_TOKEN`. The
-orchestrator passes only the one relevant token to each guardrail.
-
-Use a **GitHub App installation token** (recommended) or a **classic PAT**. The
-granular names below are GitHub App permissions; a fine-grained PAT cannot be
-used for `CI_GUARD_TOKEN` because it has no *Checks* permission.
-
-| Token | GitHub App permissions (by target repo / org) | Classic PAT scopes | Used for |
-|-------|-----------------------------------------------|--------------------|----------|
-| `MEMBERSHIP_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**, Issues: **Write** (for the override label); `pimcore` org → Members: **Read** | `repo` (or `public_repo`) + `read:org` | Team-membership lookup; read PR(s); add the `guardrails:override` label on member override. Never drafts, never comments. |
-| `ISSUE_LINK_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**; `pimcore/platform-version` → Issues: **Read** | `repo` (+ read on `platform-version` if private) | Validate linked issues exist; convert PR to draft; comment. No org permission. |
-| `CI_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**, Checks: **Read**, Commit statuses: **Read**, Contents: **Read** | `repo` | Read PR + mergeability; list checks & statuses; convert PR to draft; comment. No org permission. |
-
-Notes:
-- `Checks` is a GitHub App permission only — it is **not** available to
-  fine-grained PATs (those have `Commit statuses` but no `Checks`). For
-  `CI_GUARD_TOKEN` use a GitHub App token or a classic PAT (`repo`).
-- For a PR, both commenting and draft conversion fall under `Pull requests:
-  write` (`Issues: write` is a safe superset if your token distinguishes).
-- This collection is **public**, so the guardrails check it out anonymously to
-  load `lib.js` — the tokens need **no** access to it, and no cross-repo *Access*
-  setting is required (public reusable workflows are callable by any repo).
-
 ## Adding a new guardrail
 
 1. Add `reusable-guardrail-<x>.yml` here (`workflow_call`, one token secret).

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -74,9 +74,10 @@ is removed.
 
 If a **Dev-Team member** clicks **Ready for review** on a PR — even one opened by
 a non-member that the guardrails keep drafting — the membership stage treats it
-as an override: it adds the `guardrails:override` label and emits `bypass=true`,
-so issue-link and CI are skipped and the PR stays ready. The label persists, so
-later `check_suite` runs and pushes keep bypassing instead of re-drafting.
+as an override: it adds the `guardrails:override` label, **removes any guardrail
+failure comments**, and emits `bypass=true`, so issue-link and CI are skipped and
+the PR stays ready. The label persists, so later `check_suite` runs and pushes
+keep bypassing instead of re-drafting.
 
 ## Tokens & required settings
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -8,7 +8,7 @@ or token change happens once here instead of across every consumer repo.
 
 ```
 .github/workflows/parent-pr-guardrails.yml      orchestrator (workflow_call, no inputs)
-.github/workflows/reusable-guardrail-membership.yml   Dev-Team membership → outputs is_member
+.github/workflows/reusable-guardrail-membership.yml   Dev-Team membership / override → outputs bypass
 .github/workflows/reusable-guardrail-issue-link.yml   non-members must link a valid issue
 .github/workflows/reusable-guardrail-ci.yml           mergeable + all CI checks green
 scripts/guardrails/lib.js                       shared helpers (loaded by each guardrail)
@@ -44,15 +44,16 @@ is exempt) no comment is created, and any prior failure comment is removed.
 
 | Stage | Runs when | On failure |
 |-------|-----------|------------|
-| membership | all events (resolves author on PR + `check_suite`) | never drafts, never comments; emits `is_member` |
-| issue-link | non-draft PR events **and** author is not a Dev-Team member | draft + comment (reason + docs link) |
-| ci | all events (PR + `check_suite`) **and** author is not a Dev-Team member | draft + comment (reason) |
+| membership | all events (resolves author on PR + `check_suite`) | never drafts, never comments; emits `bypass` |
+| issue-link | non-draft PR events **and** not bypassed | draft + comment (reason + docs link) |
+| ci | all events (PR + `check_suite`) **and** not bypassed | draft + comment (reason) |
 
-- **Members are fully exempt**: if the PR author is a Dev-Team member,
-  `is_member=true` and the orchestrator **skips every other guardrail** (both
-  issue-link and CI). Non-members must link a valid issue in
-  `pimcore/platform-version` via a closing keyword (every closing-keyword
-  reference must be valid) **and** pass CI.
+- **Bypass**: the membership stage emits `bypass=true` (orchestrator skips both
+  issue-link and CI) when the PR author is a Dev-Team member, the PR carries the
+  `guardrails:override` label, or a Dev-Team member overrode it (see below).
+  Otherwise non-members must link a valid issue in `pimcore/platform-version`
+  via a closing keyword (every closing-keyword reference must be valid) **and**
+  pass CI.
 - **ci** requires the PR to be mergeable (no conflicts) and all checks/statuses
   green. It ignores any guardrail checks (name contains `guardrail`) to avoid
   self-deadlock and to not count a sibling guardrail's failure as a CI failure,
@@ -69,6 +70,14 @@ author fixes the issue and clicks **Ready for review**; the `ready_for_review`
 event re-fires the pipeline. When the guardrail then passes, its failure comment
 is removed.
 
+## Override (Dev-Team)
+
+If a **Dev-Team member** clicks **Ready for review** on a PR — even one opened by
+a non-member that the guardrails keep drafting — the membership stage treats it
+as an override: it adds the `guardrails:override` label and emits `bypass=true`,
+so issue-link and CI are skipped and the PR stays ready. The label persists, so
+later `check_suite` runs and pushes keep bypassing instead of re-drafting.
+
 ## Tokens & required settings
 
 Org-level secrets shared to consumer repos, reached via `secrets: inherit`:
@@ -81,7 +90,7 @@ used for `CI_GUARD_TOKEN` because it has no *Checks* permission.
 
 | Token | GitHub App permissions (by target repo / org) | Classic PAT scopes | Used for |
 |-------|-----------------------------------------------|--------------------|----------|
-| `MEMBERSHIP_GUARD_TOKEN` | consumer repo → Pull requests: **Read**; `pimcore` org → Members: **Read** | `repo` (or `public_repo`) + `read:org` | Team-membership lookup; read PR(s) (incl. resolving from `check_suite`). Never drafts, never comments. |
+| `MEMBERSHIP_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**, Issues: **Write** (for the override label); `pimcore` org → Members: **Read** | `repo` (or `public_repo`) + `read:org` | Team-membership lookup; read PR(s); add the `guardrails:override` label on member override. Never drafts, never comments. |
 | `ISSUE_LINK_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**; `pimcore/platform-version` → Issues: **Read** | `repo` (+ read on `platform-version` if private) | Validate linked issues exist; convert PR to draft; comment. No org permission. |
 | `CI_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**, Checks: **Read**, Commit statuses: **Read**, Contents: **Read** | `repo` | Read PR + mergeability; list checks & statuses; convert PR to draft; comment. No org permission. |
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -1,0 +1,110 @@
+# PR Guardrails (centralized)
+
+Reusable PR-guardrail pipeline. Consumer repos contain **only** a thin, generic
+trigger workflow; all logic lives here and is shared centrally, so a guardrail
+or token change happens once here instead of across every consumer repo.
+
+## Layout
+
+```
+.github/workflows/parent-pr-guardrails.yml      orchestrator (workflow_call, no inputs)
+.github/workflows/reusable-guardrail-membership.yml   Dev-Team membership → outputs is_member
+.github/workflows/reusable-guardrail-issue-link.yml   non-members must link a valid issue
+.github/workflows/reusable-guardrail-ci.yml           mergeable + all CI checks green
+scripts/guardrails/lib.js                       shared helpers (loaded by each guardrail)
+```
+
+## Consumer side (each repo, identical & frozen)
+
+```yaml
+# .github/workflows/pr-guardrails.yml
+name: PR Guardrails
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, edited, synchronize]
+  check_suite:
+    types: [completed]
+concurrency:
+  group: pr-guardrails-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  guardrails:
+    uses: pimcore/workflows-collection-public/.github/workflows/parent-pr-guardrails.yml@main
+    secrets: inherit
+```
+
+The trigger names no guardrails and no secrets (`inherit`), so it is identical
+across all repos and never needs editing when a guardrail or token is
+added/removed — that only changes this repo (+ org secrets).
+
+## Pipeline
+
+| Stage | Runs when | On failure |
+|-------|-----------|------------|
+| membership | all events (resolves author on PR + `check_suite`) | never drafts; emits `is_member` |
+| issue-link | non-draft PR events **and** author is not a Dev-Team member | draft + comment |
+| ci | all events (PR + `check_suite`) **and** author is not a Dev-Team member | draft + comment |
+
+- **Members are fully exempt**: if the PR author is a Dev-Team member,
+  `is_member=true` and the orchestrator **skips every other guardrail** (both
+  issue-link and CI). Non-members must link a valid issue in
+  `pimcore/platform-version` via a closing keyword (every closing-keyword
+  reference must be valid) **and** pass CI.
+- **ci** requires the PR to be mergeable (no conflicts) and all checks/statuses
+  green. It ignores its own `Guardrail:`-prefixed checks to avoid self-deadlock.
+- Supported keywords: `close, closes, closed, fix, fixes, fixed, resolve,
+  resolves, resolved`.
+
+## Revalidation
+
+On failure a guardrail converts the PR to **draft** and posts a single marker
+comment (updated in place on re-runs). The PR author fixes the issue and clicks
+**Ready for review**; the `ready_for_review` event re-fires the pipeline.
+
+## Tokens & required settings
+
+Org-level secrets shared to consumer repos, reached via `secrets: inherit`:
+`MEMBERSHIP_GUARD_TOKEN`, `ISSUE_LINK_GUARD_TOKEN`, `CI_GUARD_TOKEN`. The
+orchestrator passes only the one relevant token to each guardrail.
+
+Use a **GitHub App installation token** (recommended) or a **classic PAT**. The
+granular names below are GitHub App permissions; a fine-grained PAT cannot be
+used for `CI_GUARD_TOKEN` because it has no *Checks* permission.
+
+| Token | GitHub App permissions (by target repo / org) | Classic PAT scopes | Used for |
+|-------|-----------------------------------------------|--------------------|----------|
+| `MEMBERSHIP_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**; `pimcore` org → Members: **Read** | `repo` (or `public_repo`) + `read:org` | Team-membership lookup; read PR(s) (incl. resolving from `check_suite`); post membership comment. Never drafts. |
+| `ISSUE_LINK_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**; `pimcore/platform-version` → Issues: **Read** | `repo` (+ read on `platform-version` if private) | Validate linked issues exist; convert PR to draft; comment. No org permission. |
+| `CI_GUARD_TOKEN` | consumer repo → Pull requests: **R&W**, Checks: **Read**, Commit statuses: **Read**, Contents: **Read** | `repo` | Read PR + mergeability; list checks & statuses; convert PR to draft; comment. No org permission. |
+
+Notes:
+- `Checks` is a GitHub App permission only — it is **not** available to
+  fine-grained PATs (those have `Commit statuses` but no `Checks`). For
+  `CI_GUARD_TOKEN` use a GitHub App token or a classic PAT (`repo`).
+- For a PR, both commenting and draft conversion fall under `Pull requests:
+  write` (`Issues: write` is a safe superset if your token distinguishes).
+- This collection is **public**, so the guardrails check it out anonymously to
+  load `lib.js` — the tokens need **no** access to it, and no cross-repo *Access*
+  setting is required (public reusable workflows are callable by any repo).
+
+## Adding a new guardrail
+
+1. Add `reusable-guardrail-<x>.yml` here (`workflow_call`, one token secret).
+2. Add a job to `parent-pr-guardrails.yml` and pass it the token.
+3. If it needs a new token, add **one** org-level secret.
+
+No consumer repo is touched.
+
+## Configuration
+
+`lib.js` reads `GUARD_ORG`, `GUARD_TEAM_SLUG`, `GUARD_ISSUE_OWNER`,
+`GUARD_ISSUE_REPO` from the environment (defaults `pimcore` / `dev-team` /
+`pimcore/platform-version`). Confirm the **team slug** — the slug of "Dev-Team"
+is assumed to be `dev-team`.
+
+## Security
+
+All guardrails run in the caller's `pull_request_target` context but only read PR
+metadata as data and call APIs. They check out **this** (trusted) repo to load
+`lib.js`, never the PR head, so the usual `pull_request_target` code-injection
+risk does not apply. PR title/body are regex-parsed only.

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -21,7 +21,7 @@ scripts/guardrails/lib.js                       shared helpers (loaded by each g
 name: PR Guardrails
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, edited, synchronize]
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited, synchronize]
   check_suite:
     types: [completed]
 concurrency:
@@ -78,6 +78,12 @@ as an override: it adds the `guardrails:override` label, **removes any guardrail
 failure comments**, and emits `bypass=true`, so issue-link and CI are skipped and
 the PR stays ready. The label persists, so later `check_suite` runs and pushes
 keep bypassing instead of re-drafting.
+
+To **retract** an override, a Dev-Team member converts the PR back to draft
+(`converted_to_draft`): the `guardrails:override` label is removed, so the
+guardrails apply again the next time the PR is made ready. Only a member's
+draft-conversion clears it — the guardrails' own drafting (by the bot token)
+does not.
 
 ## Tokens & required settings
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -46,7 +46,7 @@ is exempt) no comment is created, and any prior failure comment is removed.
 
 | Stage | Runs when | On failure |
 |-------|-----------|------------|
-| membership | all events (resolves author on PR + `check_suite`) | never drafts, never comments; emits `bypass` |
+| membership | `check_suite`, non-draft PR events, and `converted_to_draft` (skipped on draft PR events) | never drafts, never comments; emits `bypass` |
 | issue-link | non-draft PR events **and** not bypassed | draft + comment (reason + docs link) |
 | ci | all events (PR + `check_suite`) **and** not bypassed | draft + comment (reason) |
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -54,7 +54,10 @@ is exempt) no comment is created, and any prior failure comment is removed.
   `pimcore/platform-version` via a closing keyword (every closing-keyword
   reference must be valid) **and** pass CI.
 - **ci** requires the PR to be mergeable (no conflicts) and all checks/statuses
-  green. It ignores its own `Guardrail:`-prefixed checks to avoid self-deadlock.
+  green. It ignores any guardrail checks (name contains `guardrail`) to avoid
+  self-deadlock and to not count a sibling guardrail's failure as a CI failure,
+  and considers only the latest run per check name so a stale failure that was
+  re-run green no longer counts.
 - Supported keywords: `close, closes, closed, fix, fixes, fixed, resolve,
   resolves, resolved`.
 

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -25,7 +25,9 @@ on:
   check_suite:
     types: [completed]
 concurrency:
-  group: pr-guardrails-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
+  # Separate group for converted_to_draft so a guardrail's own draft-conversion
+  # does not cancel the run that is still acting on the PR.
+  group: pr-guardrails-${{ github.event.action == 'converted_to_draft' && 'retract-' || '' }}${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
   cancel-in-progress: true
 jobs:
   guardrails:

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -174,6 +174,26 @@ async function deleteMarkerComment({ github, context, issueNumber, marker }) {
   }
 }
 
+/** Add a label to a PR/issue, creating the label in the repo if it is missing. */
+async function addLabel({ github, context, issueNumber, label }) {
+  const { owner, repo } = context.repo;
+  const issue_number = issueNumber || context.payload.pull_request.number;
+  try {
+    await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+  } catch (err) {
+    if (err.status === 404 || err.status === 422) {
+      try {
+        await github.rest.issues.createLabel({ owner, repo, name: label, color: '0e8a16' });
+      } catch (_) {
+        /* label may have been created concurrently — ignore */
+      }
+      await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+    } else {
+      throw err;
+    }
+  }
+}
+
 /** Short footer telling the author how to re-run the guardrails after fixing. */
 const REVALIDATE_HINT = 'When fixed, press **Ready for review** to re-run the checks.';
 
@@ -191,4 +211,5 @@ module.exports = {
   convertToDraft,
   upsertComment,
   deleteMarkerComment,
+  addLabel,
 };

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -6,8 +6,9 @@
 // only), never interpolated as code or commands.
 //
 // Configuration can be overridden per workflow via environment variables
-// (GUARD_ORG, GUARD_TEAM_SLUG, GUARD_ISSUE_OWNER, GUARD_ISSUE_REPO) without
-// editing this file.
+// (GUARD_ORG, GUARD_TEAM_SLUG, GUARD_ISSUE_OWNER, GUARD_ISSUE_REPO, and
+// GUARD_BOT_LOGIN — the service account the guardrails act as) without editing
+// this file.
 
 const ORG = process.env.GUARD_ORG || 'pimcore';
 const TEAM_SLUG = process.env.GUARD_TEAM_SLUG || 'dev-team'; // slug of the "Dev-Team" GitHub team
@@ -122,16 +123,22 @@ async function getMergeablePullRequest({ github, owner, repo, prNumber, attempts
   return pr;
 }
 
-/** Convert a pull request to draft via GraphQL. */
+/** Convert a pull request to draft via GraphQL. Idempotent: if the PR is already
+ *  a draft (e.g. two guardrail jobs race), the "already a draft" error is ignored. */
 async function convertToDraft({ github, pullRequestNodeId }) {
-  await github.graphql(
-    `mutation($id: ID!) {
-       convertPullRequestToDraft(input: { pullRequestId: $id }) {
-         pullRequest { isDraft }
-       }
-     }`,
-    { id: pullRequestNodeId },
-  );
+  try {
+    await github.graphql(
+      `mutation($id: ID!) {
+         convertPullRequestToDraft(input: { pullRequestId: $id }) {
+           pullRequest { isDraft }
+         }
+       }`,
+      { id: pullRequestNodeId },
+    );
+  } catch (err) {
+    if (String(err && err.message || '').toLowerCase().includes('draft')) return; // already a draft
+    throw err;
+  }
 }
 
 /**
@@ -150,9 +157,12 @@ async function upsertComment({ github, context, issueNumber, marker, body }) {
     issue_number,
     per_page: 100,
   });
-  // Handle duplicates (e.g. from a prior race): update the first marker comment
-  // and delete any extras so a single marker comment remains.
-  const matches = comments.filter((c) => c.body && c.body.includes(tag));
+  // Only manage OUR own marker comments (authored by the guard bot), so a human
+  // comment that happens to contain the marker is never mutated. Handle duplicates
+  // (e.g. from a prior race): update the first and delete any extras.
+  const matches = comments.filter(
+    (c) => c.user && c.user.login === GUARD_BOT && c.body && c.body.includes(tag),
+  );
 
   if (matches.length === 0) {
     await github.rest.issues.createComment({ owner, repo, issue_number, body: fullBody });
@@ -177,9 +187,12 @@ async function deleteMarkerComment({ github, context, issueNumber, marker }) {
     issue_number,
     per_page: 100,
   });
-  // Delete ALL matching marker comments, so duplicates (e.g. from a prior race)
-  // do not leave a stale failure comment behind.
-  const matches = comments.filter((c) => c.body && c.body.includes(tag));
+  // Delete ALL of OUR matching marker comments (authored by the guard bot), so
+  // duplicates do not leave a stale comment behind and human comments containing
+  // the marker are never deleted.
+  const matches = comments.filter(
+    (c) => c.user && c.user.login === GUARD_BOT && c.body && c.body.includes(tag),
+  );
   for (const c of matches) {
     await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
   }

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -13,6 +13,9 @@ const ORG = process.env.GUARD_ORG || 'pimcore';
 const TEAM_SLUG = process.env.GUARD_TEAM_SLUG || 'dev-team'; // slug of the "Dev-Team" GitHub team
 const ISSUE_REPO_OWNER = process.env.GUARD_ISSUE_OWNER || 'pimcore';
 const ISSUE_REPO_NAME = process.env.GUARD_ISSUE_REPO || 'platform-version';
+// Service account the guardrails act as (drafts PRs, comments). It is itself a
+// Dev-Team member, so override retraction must ignore draft-conversions by it.
+const GUARD_BOT = process.env.GUARD_BOT_LOGIN || 'pimcore-deployments';
 
 // GitHub's supported issue-closing keywords.
 const CLOSING_KEYWORDS = [
@@ -215,6 +218,7 @@ module.exports = {
   TEAM_SLUG,
   ISSUE_REPO_OWNER,
   ISSUE_REPO_NAME,
+  GUARD_BOT,
   CLOSING_KEYWORDS,
   REVALIDATE_HINT,
   isDevTeamMember,

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -194,6 +194,18 @@ async function addLabel({ github, context, issueNumber, label }) {
   }
 }
 
+/** Remove a label from a PR/issue. No-op if the label is not present. */
+async function removeLabel({ github, context, issueNumber, label }) {
+  const { owner, repo } = context.repo;
+  const issue_number = issueNumber || context.payload.pull_request.number;
+  try {
+    await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+  } catch (err) {
+    if (err.status === 404) return; // label not on the PR — nothing to do
+    throw err;
+  }
+}
+
 /** Short footer telling the author how to re-run the guardrails after fixing. */
 const REVALIDATE_HINT = 'When fixed, press **Ready for review** to re-run the checks.';
 
@@ -212,4 +224,5 @@ module.exports = {
   upsertComment,
   deleteMarkerComment,
   addLabel,
+  removeLabel,
 };

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -155,10 +155,24 @@ async function upsertComment({ github, context, issueNumber, marker, body }) {
   }
 }
 
-/** Shared "how to revalidate" footer for failure comments. */
-const REVALIDATE_HINT =
-  '**To revalidate:** fix the issue above, then click **“Ready for review”** on this PR. ' +
-  'The guardrail re-runs automatically and, if it passes, the PR stays ready.';
+/** Delete the marker comment if present (used when a guardrail now passes, so a
+ *  stale failure comment does not linger). No-op when there is nothing to remove. */
+async function deleteMarkerComment({ github, context, issueNumber, marker }) {
+  const { owner, repo } = context.repo;
+  const issue_number = issueNumber || context.payload.pull_request.number;
+  const tag = `<!-- ${marker} -->`;
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number,
+    per_page: 100,
+  });
+  const existing = comments.find((c) => c.body && c.body.includes(tag));
+  if (existing) {
+    await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+  }
+}
 
 module.exports = {
   ORG,
@@ -166,11 +180,11 @@ module.exports = {
   ISSUE_REPO_OWNER,
   ISSUE_REPO_NAME,
   CLOSING_KEYWORDS,
-  REVALIDATE_HINT,
   isDevTeamMember,
   parseIssueReferences,
   validateIssue,
   getMergeablePullRequest,
   convertToDraft,
   upsertComment,
+  deleteMarkerComment,
 };

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -79,8 +79,9 @@ function parseIssueReferences(text, { defaultOwner = ISSUE_REPO_OWNER, defaultRe
 }
 
 /**
- * Validate that an issue reference points to a real, open issue (not a PR).
- * Returns { valid, reason?, state? }.
+ * Validate that an issue reference points to a real, existing issue (not a pull
+ * request). The issue may be open or closed — state is returned for the caller,
+ * but a closed tracking issue is still a valid link. Returns { valid, reason?, state? }.
  */
 async function validateIssue({ github, owner, repo, number }) {
   try {

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -174,12 +174,16 @@ async function deleteMarkerComment({ github, context, issueNumber, marker }) {
   }
 }
 
+/** Short footer telling the author how to re-run the guardrails after fixing. */
+const REVALIDATE_HINT = 'When fixed, press **Ready for review** to re-run the checks.';
+
 module.exports = {
   ORG,
   TEAM_SLUG,
   ISSUE_REPO_OWNER,
   ISSUE_REPO_NAME,
   CLOSING_KEYWORDS,
+  REVALIDATE_HINT,
   isDevTeamMember,
   parseIssueReferences,
   validateIssue,

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -150,12 +150,17 @@ async function upsertComment({ github, context, issueNumber, marker, body }) {
     issue_number,
     per_page: 100,
   });
-  const existing = comments.find((c) => c.body && c.body.includes(tag));
+  // Handle duplicates (e.g. from a prior race): update the first marker comment
+  // and delete any extras so a single marker comment remains.
+  const matches = comments.filter((c) => c.body && c.body.includes(tag));
 
-  if (existing) {
-    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: fullBody });
-  } else {
+  if (matches.length === 0) {
     await github.rest.issues.createComment({ owner, repo, issue_number, body: fullBody });
+    return;
+  }
+  await github.rest.issues.updateComment({ owner, repo, comment_id: matches[0].id, body: fullBody });
+  for (const dup of matches.slice(1)) {
+    await github.rest.issues.deleteComment({ owner, repo, comment_id: dup.id });
   }
 }
 
@@ -172,9 +177,11 @@ async function deleteMarkerComment({ github, context, issueNumber, marker }) {
     issue_number,
     per_page: 100,
   });
-  const existing = comments.find((c) => c.body && c.body.includes(tag));
-  if (existing) {
-    await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+  // Delete ALL matching marker comments, so duplicates (e.g. from a prior race)
+  // do not leave a stale failure comment behind.
+  const matches = comments.filter((c) => c.body && c.body.includes(tag));
+  for (const c of matches) {
+    await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
   }
 }
 

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -1,0 +1,176 @@
+// Shared helpers for the PR guardrail workflows.
+//
+// SECURITY: These helpers are invoked only from `pull_request_target` workflows
+// that check out the trusted base ref. PR head code is NEVER checked out or
+// executed. PR title/body are treated strictly as untrusted data (regex-parsed
+// only), never interpolated as code or commands.
+//
+// Configuration can be overridden per workflow via environment variables
+// (GUARD_ORG, GUARD_TEAM_SLUG, GUARD_ISSUE_OWNER, GUARD_ISSUE_REPO) without
+// editing this file.
+
+const ORG = process.env.GUARD_ORG || 'pimcore';
+const TEAM_SLUG = process.env.GUARD_TEAM_SLUG || 'dev-team'; // slug of the "Dev-Team" GitHub team
+const ISSUE_REPO_OWNER = process.env.GUARD_ISSUE_OWNER || 'pimcore';
+const ISSUE_REPO_NAME = process.env.GUARD_ISSUE_REPO || 'platform-version';
+
+// GitHub's supported issue-closing keywords.
+const CLOSING_KEYWORDS = [
+  'close', 'closes', 'closed',
+  'fix', 'fixes', 'fixed',
+  'resolve', 'resolves', 'resolved',
+];
+
+/**
+ * Returns true if `username` is an active member of org/teamSlug.
+ * Requires a token with `read:org` that can see the team.
+ */
+async function isDevTeamMember({ github, username, org = ORG, teamSlug = TEAM_SLUG }) {
+  try {
+    const res = await github.rest.teams.getMembershipForUserInOrg({
+      org,
+      team_slug: teamSlug,
+      username,
+    });
+    return res.data.state === 'active';
+  } catch (err) {
+    if (err.status === 404) return false; // not a member
+    throw err;
+  }
+}
+
+/**
+ * Parse closing-keyword issue references from arbitrary text.
+ * Matches `keyword #123`, `keyword owner/repo#123`, and
+ * `keyword https://github.com/owner/repo/issues/123`.
+ * Returns array of { keyword, owner, repo, number, raw }.
+ */
+function parseIssueReferences(text, { defaultOwner = ISSUE_REPO_OWNER, defaultRepo = ISSUE_REPO_NAME } = {}) {
+  if (!text) return [];
+  const refs = [];
+  const kw = CLOSING_KEYWORDS.join('|');
+
+  // keyword [owner/repo]#123
+  const shortRe = new RegExp(`\\b(${kw})\\b\\s*:?\\s+(?:([\\w.-]+)\\/([\\w.-]+))?#(\\d+)`, 'gi');
+  let m;
+  while ((m = shortRe.exec(text)) !== null) {
+    refs.push({
+      keyword: m[1].toLowerCase(),
+      owner: m[2] || defaultOwner,
+      repo: m[3] || defaultRepo,
+      number: parseInt(m[4], 10),
+      raw: m[0].trim().replace(/\s+/g, ' '),
+    });
+  }
+
+  // keyword https://github.com/owner/repo/issues/123
+  const urlRe = new RegExp(`\\b(${kw})\\b\\s*:?\\s+https?:\\/\\/github\\.com\\/([\\w.-]+)\\/([\\w.-]+)\\/issues\\/(\\d+)`, 'gi');
+  while ((m = urlRe.exec(text)) !== null) {
+    refs.push({
+      keyword: m[1].toLowerCase(),
+      owner: m[2],
+      repo: m[3],
+      number: parseInt(m[4], 10),
+      raw: m[0].trim().replace(/\s+/g, ' '),
+    });
+  }
+
+  return refs;
+}
+
+/**
+ * Validate that an issue reference points to a real, open issue (not a PR).
+ * Returns { valid, reason?, state? }.
+ */
+async function validateIssue({ github, owner, repo, number }) {
+  try {
+    const res = await github.rest.issues.get({ owner, repo, issue_number: number });
+    if (res.data.pull_request) {
+      return { valid: false, reason: 'reference points to a pull request, not an issue' };
+    }
+    return { valid: true, state: res.data.state };
+  } catch (err) {
+    if (err.status === 404) return { valid: false, reason: 'issue not found' };
+    if (err.status === 401 || err.status === 403) {
+      return { valid: false, reason: 'token cannot access this issue (check token scopes)' };
+    }
+    throw err;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch a PR, polling until GitHub finishes computing `mergeable` (which is
+ * null for a short window after each push). Returns the PR object; `mergeable`
+ * may still be null if the computation did not settle within the budget, in
+ * which case callers should treat it as "pending", not "failed".
+ */
+async function getMergeablePullRequest({ github, owner, repo, prNumber, attempts = 5, delayMs = 3000 }) {
+  let pr;
+  for (let i = 0; i < attempts; i++) {
+    ({ data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber }));
+    if (pr.mergeable !== null || pr.state !== 'open') return pr;
+    await sleep(delayMs);
+  }
+  return pr;
+}
+
+/** Convert a pull request to draft via GraphQL. */
+async function convertToDraft({ github, pullRequestNodeId }) {
+  await github.graphql(
+    `mutation($id: ID!) {
+       convertPullRequestToDraft(input: { pullRequestId: $id }) {
+         pullRequest { isDraft }
+       }
+     }`,
+    { id: pullRequestNodeId },
+  );
+}
+
+/**
+ * Create or update a single marker comment so re-runs update in place instead
+ * of posting duplicate comments.
+ */
+async function upsertComment({ github, context, issueNumber, marker, body }) {
+  const { owner, repo } = context.repo;
+  const issue_number = issueNumber || context.payload.pull_request.number;
+  const tag = `<!-- ${marker} -->`;
+  const fullBody = `${body}\n\n${tag}`;
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number,
+    per_page: 100,
+  });
+  const existing = comments.find((c) => c.body && c.body.includes(tag));
+
+  if (existing) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: fullBody });
+  } else {
+    await github.rest.issues.createComment({ owner, repo, issue_number, body: fullBody });
+  }
+}
+
+/** Shared "how to revalidate" footer for failure comments. */
+const REVALIDATE_HINT =
+  '**To revalidate:** fix the issue above, then click **“Ready for review”** on this PR. ' +
+  'The guardrail re-runs automatically and, if it passes, the PR stays ready.';
+
+module.exports = {
+  ORG,
+  TEAM_SLUG,
+  ISSUE_REPO_OWNER,
+  ISSUE_REPO_NAME,
+  CLOSING_KEYWORDS,
+  REVALIDATE_HINT,
+  isDevTeamMember,
+  parseIssueReferences,
+  validateIssue,
+  getMergeablePullRequest,
+  convertToDraft,
+  upsertComment,
+};


### PR DESCRIPTION
Adds a centralized, reusable PR-guardrail pipeline that consumer repos invoke with a single generic trigger (`uses:` the orchestrator + `secrets: inherit`).

## What it adds
- `.github/workflows/parent-pr-guardrails.yml` — orchestrator (`workflow_call`); runs membership → issue-link → CI, gating later stages on the membership `bypass` output.
- `.github/workflows/reusable-guardrail-membership.yml` — Dev-Team membership + override handling; emits `bypass`.
- `.github/workflows/reusable-guardrail-issue-link.yml` — non-members must link a valid `pimcore/platform-version` issue via a closing keyword.
- `.github/workflows/reusable-guardrail-ci.yml` — PR must be mergeable (no conflicts) and all CI checks green.
- `scripts/guardrails/lib.js` + `README.md` — shared helpers and docs.

## Behavior
- **Bypass**: Dev-Team member author, the `guardrails:override` label, or a member pressing **Ready for review** (override) skips issue-link + CI.
- **Override**: a member's *Ready for review* adds the `guardrails:override` label and clears failure comments; converting back to draft (member) removes it.
- **Failures** convert the PR to draft with a short reason + how-to; comments only on failure and are removed on pass.

## Notes
- Public repo, so consumers check it out anonymously to load `lib.js`.
- Consumer trigger must list `converted_to_draft` (for override retraction) — see the README example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)