### PR TITLE
Exempt PRs opened before a start date (default 2026-07-07)

### DIFF
--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -94,6 +94,10 @@ jobs:
                 core.info(`PR #${prNumber} is a draft; skipping (work in progress).`);
                 return null;
               }
+              if (lib.isExemptByAge(pr)) {
+                core.info(`PR #${prNumber} predates ${lib.START_DATE}; skipping (exempt).`);
+                return null;
+              }
               const headSha = pr.head.sha;
 
               const failures = [];

--- a/.github/workflows/reusable-guardrail-issue-link.yml
+++ b/.github/workflows/reusable-guardrail-issue-link.yml
@@ -43,6 +43,12 @@ jobs:
             const pr = context.payload.pull_request;
             const issueNumber = pr.number;
 
+            // PRs opened before the start date are exempt (not checked).
+            if (lib.isExemptByAge(pr)) {
+              core.info(`PR #${pr.number} predates ${lib.START_DATE} — exempt from issue-link guardrail.`);
+              return;
+            }
+
             // Parse closing-keyword references from title + body (untrusted data).
             const text = `${pr.title}\n\n${pr.body || ''}`;
             const refs = lib.parseIssueReferences(text);

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -117,8 +117,14 @@ jobs:
             let allBypass = true;
             const bypassedPrs = [];
             for (const pr of prs) {
+              // PRs opened before the start date are exempt (checked before any
+              // API call). Then override label, then Dev-Team membership.
+              const ageExempt = lib.isExemptByAge(pr);
               const hasLabel = (pr.labels || []).some((l) => l.name === OVERRIDE_LABEL);
-              let bypass = hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+              let bypass = ageExempt || hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+              if (ageExempt) {
+                core.info(`PR #${pr.number} created ${pr.created_at} is before start date ${lib.START_DATE} — exempt.`);
+              }
 
               if (!bypass && isReadyForReview && actor
                   && await lib.isDevTeamMember({ github, username: actor })) {

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -50,6 +50,9 @@ is exempt) no comment is created, and any prior failure comment is removed.
 | issue-link | non-draft PR events **and** not bypassed | draft + comment (reason + docs link) |
 | ci | all events (PR + `check_suite`) **and** not bypassed | draft + comment (reason) |
 
+- **Age exemption**: PRs created **before `GUARD_START_DATE`** (default
+  `2026-07-07`) are exempt — every guardrail skips them, so the policy only
+  applies to PRs opened on/after that date.
 - **Bypass**: the membership stage emits `bypass=true` (orchestrator skips both
   issue-link and CI) when the PR author is a Dev-Team member, the PR carries the
   `guardrails:override` label, or a Dev-Team member overrode it (see below).
@@ -107,6 +110,9 @@ No consumer repo is touched.
   override retraction, and (b) restrict marker-comment management to the bot's
   own comments. **Set this if your guardrail tokens belong to a different
   account**, or retraction and comment cleanup will misbehave.
+- `GUARD_START_DATE` (default `2026-07-07`) — only PRs **created on/after** this
+  date are checked; older PRs are exempt (all guardrails skip). Set to empty to
+  disable the date gate and check every PR.
 
 ## Security
 

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -17,6 +17,9 @@ const ISSUE_REPO_NAME = process.env.GUARD_ISSUE_REPO || 'platform-version';
 // Service account the guardrails act as (drafts PRs, comments). It is itself a
 // Dev-Team member, so override retraction must ignore draft-conversions by it.
 const GUARD_BOT = process.env.GUARD_BOT_LOGIN || 'pimcore-deployments';
+// Only PRs created on/after this date are checked; older PRs are exempt. Empty
+// disables the date gate. ISO date (UTC) — e.g. "2026-07-07".
+const START_DATE = process.env.GUARD_START_DATE || '2026-07-07';
 
 // GitHub's supported issue-closing keywords.
 const CLOSING_KEYWORDS = [
@@ -24,6 +27,16 @@ const CLOSING_KEYWORDS = [
   'fix', 'fixes', 'fixed',
   'resolve', 'resolves', 'resolved',
 ];
+
+/**
+ * True if the PR predates the guardrail start date and is therefore exempt.
+ * Older PRs (opened before START_DATE) are not checked. Returns false if no
+ * start date is configured or the PR has no created_at.
+ */
+function isExemptByAge(pr, startDate = START_DATE) {
+  if (!startDate || !pr || !pr.created_at) return false;
+  return new Date(pr.created_at).getTime() < new Date(startDate).getTime();
+}
 
 /**
  * Returns true if `username` is an active member of org/teamSlug.
@@ -239,8 +252,10 @@ module.exports = {
   ISSUE_REPO_OWNER,
   ISSUE_REPO_NAME,
   GUARD_BOT,
+  START_DATE,
   CLOSING_KEYWORDS,
   REVALIDATE_HINT,
+  isExemptByAge,
   isDevTeamMember,
   parseIssueReferences,
   validateIssue,


### PR DESCRIPTION
Only PRs **created on/after `GUARD_START_DATE`** (default `2026-07-07`) are checked; older PRs are exempt and all guardrails skip them.

- New `GUARD_START_DATE` env (ISO date, UTC) + `lib.isExemptByAge(pr)`.
- Membership folds the age check into `bypass` (so issue-link & CI skip old PRs via the normal gate + `bypassed_prs`).
- issue-link and CI also self-check `isExemptByAge` as defense-in-depth, so an old PR is never enforced even if the membership stage is skipped or errors.
- Set `GUARD_START_DATE` to empty to disable the date gate.

Date math is in JS (GitHub Actions `if:` expressions can't compare dates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)