### PR TITLE
fix: skip release creation when tag already exists

### DIFF
--- a/.github/workflows/create-major-minor-release.yaml
+++ b/.github/workflows/create-major-minor-release.yaml
@@ -372,6 +372,7 @@ jobs:
       AUTO_CHANGELOG: ${{ needs.prepare.outputs.auto_changelog_norm }}
     steps:
       - name: Ensure tag does not already exist
+        id: tag_check
         shell: bash
         run: |
           set -euo pipefail
@@ -382,11 +383,14 @@ jobs:
             -H "Authorization: Bearer ${RELEASE_TOKEN}")
 
           if [[ "${CHECK_TAG}" -eq 200 ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "⚠️ Tag ${TAG_NAME} already exists on ${OWNER}/${REPO}; skipping" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create release
+        if: steps.tag_check.outputs.exists == 'false'
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
The create-major-minor-release workflow was hard-failing when a tag already existed on a repo, which caused the entire matrix job to fail and blocked releases for other repos.

Changed the tag check step to emit an output instead of exiting with code 1, and gated the release creation step on that output so repos with an existing tag are skipped gracefully.

https://github.com/pimcore/workflows-collection-public/actions/runs/28386245393/job/84121542236

ee:  v2026.2.0 was existing before in ee-customer-data-framework