### PR TITLE
Workflow 1 read-only triage (plan mode): classification, dedup, versions source

### DIFF
--- a/.github/workflows/advisory-triage.yml
+++ b/.github/workflows/advisory-triage.yml
@@ -1,0 +1,52 @@
+name: Advisory Triage
+
+# Read-only "plan mode" for Workflow 1: for the recent advisories on the source
+# repo, decide what the automation WOULD do (fetch -> dedup -> classify ->
+# resolve target branch) and print the plan. Creates nothing — no tickets, no
+# PRs, no writes. Trigger manually from the Actions tab, or weekly.
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Advisory source repo"
+        required: false
+        default: "pimcore/pimcore"
+        type: string
+      limit:
+        description: "Max number of recent advisories to evaluate"
+        required: false
+        default: "30"
+        type: string
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        env:
+          SRC_REPO: ${{ inputs.repo || 'pimcore/pimcore' }}
+          LIMIT: ${{ inputs.limit || '30' }}
+        with:
+          # Prefer a PAT that can read repository security advisories (incl.
+          # triage state) and search issues/PRs org-wide; fall back to the
+          # workflow token. If the token lacks advisory read access the
+          # request 404s/403s — add an ADVISORY_READ_TOKEN secret then.
+          github-token: ${{ secrets.ADVISORY_READ_TOKEN != '' && secrets.ADVISORY_READ_TOKEN || github.token }}
+          script: |
+            const { runTriage } = require(`${process.env.GITHUB_WORKSPACE}/scripts/security-advisory-automation/index.js`);
+            // Public repo: non-published advisories are redacted in the log. Full detail is
+            // available only via the local CLI (`node cli.js --triage`).
+            await runTriage({
+              github,
+              sourceRepo: process.env.SRC_REPO,
+              limit: parseInt(process.env.LIMIT, 10) || 30,
+              log: core.info,
+              publicSafe: true,
+            });

--- a/.github/workflows/advisory-versions-drift.yml
+++ b/.github/workflows/advisory-versions-drift.yml
@@ -26,16 +26,17 @@ jobs:
           node -e '
             const fs = require("fs");
             const { loadSupportedVersions } = require("./lib/versions");
-            const { detectNewRelease } = require("./lib/versions-drift");
+            const { evaluateDrift } = require("./lib/versions-drift");
             const cfg = loadSupportedVersions();
             const page = fs.readFileSync("/tmp/platform-versions.html", "utf8");
-            const r = detectNewRelease(cfg, page);
-            const line = r.drifted
-              ? `⚠️ Docs page shows ${r.newest}, newer than configured activeBugfixLine ${r.active}. Update config/supported-versions.json (see the page).`
-              : `✅ No new release beyond configured activeBugfixLine ${r.active} (newest on docs: ${r.newest}).`;
+            const r = evaluateDrift(cfg, page);
+            const icon = r.status === "ok" ? "✅" : r.status === "drift" ? "⚠️" : "❌";
+            const line = `${icon} ${r.message}`;
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, line + "\n");
             console.log(line);
-            if (r.drifted) process.exit(1);
+            // Fail loud on both drift AND an unparseable page (a broken scraper
+            // must not look like "no drift").
+            if (r.status !== "ok") process.exit(1);
             // NOTE: to actively notify, a follow-up can open/update a tracking
             // issue here via github-script (issues:write on this repo).
           '

--- a/.github/workflows/advisory-versions-drift.yml
+++ b/.github/workflows/advisory-versions-drift.yml
@@ -1,0 +1,41 @@
+name: Advisory Supported-Versions Drift Check
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scripts/security-advisory-automation
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Fetch Platform Versions page
+        run: curl -sSL "https://docs.pimcore.com/platform/Pimcore_Platform/Platform_Versions/" -o /tmp/platform-versions.html
+      - name: Check for drift vs config/supported-versions.json
+        run: |
+          node -e '
+            const fs = require("fs");
+            const { loadSupportedVersions } = require("./lib/versions");
+            const { detectNewRelease } = require("./lib/versions-drift");
+            const cfg = loadSupportedVersions();
+            const page = fs.readFileSync("/tmp/platform-versions.html", "utf8");
+            const r = detectNewRelease(cfg, page);
+            const line = r.drifted
+              ? `⚠️ Docs page shows ${r.newest}, newer than configured activeBugfixLine ${r.active}. Update config/supported-versions.json (see the page).`
+              : `✅ No new release beyond configured activeBugfixLine ${r.active} (newest on docs: ${r.newest}).`;
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, line + "\n");
+            console.log(line);
+            if (r.drifted) process.exit(1);
+            // NOTE: to actively notify, a follow-up can open/update a tracking
+            // issue here via github-script (issues:write on this repo).
+          '

--- a/scripts/security-advisory-automation/README.md
+++ b/scripts/security-advisory-automation/README.md
@@ -13,9 +13,16 @@ later phase.
   - `lib/branches.js` — `isUnifiedEra`, `parseCompatibleLine`,
     `selectLowestActiveLine`, `eeRepoName`, `selectBranchRepo`
   - `lib/advisory.js` / `lib/routing.js` — parse an advisory and produce routing decisions
+  - `lib/triage.js` — `classifyAdvisory` (already-handled / not-applicable /
+    actionable) and `artifactSearchQuery` (org-wide dedup search)
+  - `lib/versions.js` — `loadSupportedVersions`, `lowestActiveBugfixLine`, `ltsLinesInScope`
   - `lib/source.js` — thin read-only `gh api` wrappers (local) and octokit wrappers (CI)
-  - `lib/report.js` — `buildReport`, `formatReport`, `BANNER`
-- `index.js` — re-exports the full public API; `runDryRun` for use via `github-script`
+  - `lib/report.js` — `buildReport`, `formatReport`, `BANNER` (single-advisory dry run)
+  - `lib/orchestrate.js` — read-only **Workflow 1** orchestration: `runTriage`
+    (fetch → dedup → classify → resolve target branch), plus its GET-only
+    octokit helpers `searchHandled`, `branchExists`, `resolveFixLocation`
+  - `lib/triage-report.js` — `formatTriagePlan`, `BANNER` (triage-sweep report)
+- `index.js` — re-exports the full public API; `runDryRun` / `runTriage` for use via `github-script`
 - `cli.js` — thin local CLI (shells to `gh`); convenience only, not used in CI
 - `tests/*.test.js` — node:test suite (pure-logic, no network)
 
@@ -65,3 +72,41 @@ Because this repository is public and Actions logs are world-readable, the CI
 dry-run **redacts non-published advisories** (prints only a minimal
 acknowledgment with the GHSA id and state). Use the local CLI for full detail
 on `triage`/unpublished advisories.
+
+## Triage (plan mode)
+
+Workflow 1's read-only "plan mode": for the most recent advisories on the
+source repo, sweep through fetch → dedup (org-wide issue/PR search) → classify
+(`already-handled` / `not-applicable` / `actionable`) → for actionable
+advisories, resolve the initial fix location (base repo, else its `ee-*`
+counterpart, else human-fallback) and the LTS backport lines in scope. Prints
+a plan. **Strictly read-only** — every `github.request` call is a GET; nothing
+is ticketed, opened, or written.
+
+### Locally (full detail)
+
+Requires an authenticated `gh` with read access to the advisory source repo
+and to search issues/PRs. Runs against a small octokit-shim over `gh api`, not
+octokit — so no local Node dependencies beyond `gh` itself.
+
+```bash
+cd scripts/security-advisory-automation
+node cli.js --triage [--repo pimcore/pimcore] [--limit N]
+```
+
+This runs with `publicSafe: false`, so `triage`/unpublished advisories are
+shown in full (severity, affected packages, resolved branch, LTS scope) —
+appropriate for a local run, never for a public log.
+
+### In CI (read-only, redacted)
+
+The `Advisory Triage` workflow (`workflow_dispatch`, plus an optional weekly
+schedule) runs `runTriage` via `actions/github-script` (octokit only). It runs
+with `permissions: contents: read, security-events: read` and `publicSafe:
+true`: non-`published` advisories are shown as a minimal redacted line (no
+severity, package, or repo) since Actions logs on this public repo are
+world-readable. Trigger it manually from the Actions tab, optionally
+overriding the source repo or the number of advisories to evaluate.
+
+If the workflow token lacks advisory read (or org search) access, add an
+`ADVISORY_READ_TOKEN` secret (a PAT with security-advisory read scope).

--- a/scripts/security-advisory-automation/cli.js
+++ b/scripts/security-advisory-automation/cli.js
@@ -2,24 +2,108 @@
 // Local read-only dry run. Usage:
 //   node cli.js GHSA-xxxx-xxxx-xxxx [--repo pimcore/pimcore]
 //   node cli.js --latest 5 [--repo pimcore/pimcore]
+//   node cli.js --triage [--repo pimcore/pimcore] [--limit N]
 // In CI the dry run runs via the github-script workflow (octokit), not this CLI.
+const { execFileSync } = require('child_process');
 const { fetchAdvisoryViaGh, fetchLatestViaGh } = require('./lib/source');
 const { buildReport } = require('./lib/report');
 const { extractGhsaId } = require('./lib/ghsa');
+const { runTriage } = require('./lib/orchestrate');
 
 function parseArgs(argv) {
-  const args = { repo: 'pimcore/pimcore', ghsaId: undefined, latest: undefined };
+  const args = {
+    repo: 'pimcore/pimcore',
+    ghsaId: undefined,
+    latest: undefined,
+    triage: false,
+    limit: undefined,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--repo') args.repo = argv[++i];
     else if (a === '--latest') args.latest = parseInt(argv[++i], 10);
+    else if (a === '--triage') args.triage = true;
+    else if (a === '--limit') args.limit = parseInt(argv[++i], 10);
     else if (!a.startsWith('--')) args.ghsaId = a;
   }
   return args;
 }
 
-function main(argv) {
-  const { repo, ghsaId, latest } = parseArgs(argv);
+/**
+ * Build the `gh api` path (+ query string) for an octokit-style
+ * `request(route, params)` call. Path params (`{owner}`) are substituted;
+ * any remaining params become the query string. Read-only: GET only.
+ * @param {string} route - e.g. "GET /repos/{owner}/{repo}/branches/{branch}"
+ * @param {object} params
+ * @returns {string}
+ */
+function buildGhPath(route, params = {}) {
+  const [method, template] = route.split(' ');
+  if (method !== 'GET') {
+    throw new Error(`ghShim is read-only; refusing non-GET route: ${route}`);
+  }
+  const used = new Set();
+  let path = template.replace(/\{(\w+)\}/g, (_, key) => {
+    used.add(key);
+    if (!(key in params)) throw new Error(`missing param "${key}" for route ${route}`);
+    return encodeURIComponent(params[key]);
+  });
+  const queryKeys = Object.keys(params).filter((k) => !used.has(k));
+  if (queryKeys.length) {
+    const qs = queryKeys
+      .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
+      .join('&');
+    path += (path.includes('?') ? '&' : '?') + qs;
+  }
+  return path.replace(/^\//, '');
+}
+
+/**
+ * Tiny octokit-shim over `gh api` so `runTriage` (written against
+ * `github.request`) also works locally without octokit. Read-only: every
+ * call is a GET; nothing here can mutate GitHub state.
+ * @returns {{ request: (route:string, params?:object) => Promise<{data:any}> }}
+ */
+function makeGhShim() {
+  return {
+    async request(route, params = {}) {
+      const path = buildGhPath(route, params);
+      try {
+        const output = execFileSync('gh', ['api', path], { encoding: 'utf8' });
+        return { data: JSON.parse(output) };
+      } catch (err) {
+        const stderr = String((err && err.stderr) || (err && err.message) || '');
+        const match = /HTTP (\d+)/.exec(stderr);
+        const wrapped = new Error(stderr || 'gh api failed');
+        if (match) wrapped.status = parseInt(match[1], 10);
+        throw wrapped;
+      }
+    },
+  };
+}
+
+async function main(argv) {
+  const { repo, ghsaId, latest, triage, limit } = parseArgs(argv);
+
+  if (triage) {
+    try {
+      await runTriage({
+        github: makeGhShim(),
+        sourceRepo: repo,
+        limit: limit || 30,
+        publicSafe: false, // local CLI: full detail
+        log: console.log,
+      });
+      return 0;
+    } catch (err) {
+      console.error(
+        `error: could not run triage on ${repo}. Check that \`gh\` is authenticated with advisory read access.`
+      );
+      console.error(String((err && err.message) || err).split('\n')[0]);
+      return 1;
+    }
+  }
+
   let raws;
   try {
     if (latest) {
@@ -32,7 +116,7 @@ function main(argv) {
       }
       raws = [fetchAdvisoryViaGh(repo, id)];
     } else {
-      console.error('error: provide a GHSA id or --latest N');
+      console.error('error: provide a GHSA id, --latest N, or --triage');
       return 2;
     }
   } catch (err) {
@@ -46,5 +130,7 @@ function main(argv) {
   return 0;
 }
 
-if (require.main === module) process.exit(main(process.argv.slice(2)));
-module.exports = { parseArgs, main };
+if (require.main === module) {
+  Promise.resolve(main(process.argv.slice(2))).then((code) => process.exit(code));
+}
+module.exports = { parseArgs, main, buildGhPath, makeGhShim };

--- a/scripts/security-advisory-automation/config/supported-versions.json
+++ b/scripts/security-advisory-automation/config/supported-versions.json
@@ -1,0 +1,12 @@
+{
+  "_source": "https://docs.pimcore.com/platform/Pimcore_Platform/Platform_Versions/",
+  "_note": "Mirror of the Pimcore Platform Versions doc page. Update deliberately when the page changes; the advisory-versions-drift workflow flags new releases.",
+  "lastReviewed": "2026-07-03",
+  "activeBugfixLine": "2026.1",
+  "ltsLines": [
+    { "line": "2025.4", "supportUntil": "2028-12-31" },
+    { "line": "2024.4", "supportUntil": "2026-12-31" },
+    { "line": "2023.3", "supportUntil": "2025-12-31" },
+    { "line": "2022.0", "supportUntil": "2025-08-31" }
+  ]
+}

--- a/scripts/security-advisory-automation/index.js
+++ b/scripts/security-advisory-automation/index.js
@@ -20,6 +20,7 @@ const {
   fetchAdvisoryViaOctokit,
   fetchLatestViaOctokit,
 } = require('./lib/source');
+const { runTriage } = require('./lib/orchestrate');
 
 /**
  * Dry-run: fetch advisory/advisories and log the routing report.
@@ -87,4 +88,5 @@ module.exports = {
   fetchLatestViaOctokit,
   // orchestration
   runDryRun,
+  runTriage,
 };

--- a/scripts/security-advisory-automation/lib/orchestrate.js
+++ b/scripts/security-advisory-automation/lib/orchestrate.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { parseAdvisory } = require('./advisory');
+const { classifyAdvisory, artifactSearchQuery } = require('./triage');
+const { eeRepoName, selectBranchRepo } = require('./branches');
+const { loadSupportedVersions, lowestActiveBugfixLine, ltsLinesInScope } = require('./versions');
+const { fetchLatestViaOctokit } = require('./source');
+
+function splitRepo(repo) {
+  const i = repo.indexOf('/');
+  return { owner: repo.slice(0, i), name: repo.slice(i + 1) };
+}
+
+/** True if any open/merged issue or PR in the org already references the GHSA id. */
+async function searchHandled(github, org, ghsaId) {
+  const res = await github.request('GET /search/issues', { q: artifactSearchQuery(org, ghsaId) });
+  return (res.data && res.data.total_count > 0) || false;
+}
+
+/** True if `branch` exists in `repo`. 404 -> false; other errors rethrow. */
+async function branchExists(github, repo, branch) {
+  const { owner, name } = splitRepo(repo);
+  try {
+    await github.request('GET /repos/{owner}/{repo}/branches/{branch}', { owner, repo: name, branch });
+    return true;
+  } catch (err) {
+    if (err && err.status === 404) return false;
+    throw err;
+  }
+}
+
+/**
+ * Resolve where the initial fix lands for a given line: the base repo if the
+ * branch is there, else the ee-* counterpart, else null (human-fallback).
+ * @returns {Promise<{repo:string, branch:string}|null>}
+ */
+async function resolveFixLocation(github, fixRepo, line) {
+  const inBase = await branchExists(github, fixRepo, line);
+  const inEe = inBase ? false : await branchExists(github, eeRepoName(fixRepo), line);
+  try {
+    return { repo: selectBranchRepo(fixRepo, inBase, inEe), branch: line };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read-only triage sweep. Returns a plan (array of entries) and logs the report.
+ * @param {{ github:object, sourceRepo?:string, org?:string, limit?:number, now?:Date, log?:function, publicSafe?:boolean, config?:object }} opts
+ */
+async function runTriage(opts) {
+  const {
+    github,
+    sourceRepo = 'pimcore/pimcore',
+    org = splitRepo(sourceRepo).owner,
+    limit = 30,
+    now = new Date(),
+    log = console.log,
+    publicSafe = true,
+    config = loadSupportedVersions(),
+  } = opts;
+
+  const raws = await fetchLatestViaOctokit(github, sourceRepo, limit);
+  const line = lowestActiveBugfixLine(config);
+  const entries = [];
+
+  for (const raw of raws) {
+    const advisory = parseAdvisory(raw);
+    const handled = advisory.ghsaId ? await searchHandled(github, org, advisory.ghsaId) : false;
+    const c = classifyAdvisory(advisory, { handled });
+    const entry = {
+      ghsaId: c.ghsaId, state: c.state, outcome: c.outcome,
+      reason: c.reason, severity: c.severity, targets: [],
+    };
+    if (c.outcome === 'actionable') {
+      for (const d of c.decisions) {
+        const loc = await resolveFixLocation(github, d.fixRepo, line);
+        entry.targets.push({
+          package: d.package,
+          fixRepo: d.fixRepo,
+          location: loc, // {repo, branch} or null (human-fallback)
+          ltsInScope: d.ltsInScope,
+          ltsLines: d.ltsInScope ? ltsLinesInScope(config, now) : [],
+        });
+      }
+    }
+    entries.push(entry);
+  }
+
+  log(require('./triage-report').formatTriagePlan(entries, { publicSafe }));
+  return entries;
+}
+
+module.exports = { splitRepo, searchHandled, branchExists, resolveFixLocation, runTriage };

--- a/scripts/security-advisory-automation/lib/triage-report.js
+++ b/scripts/security-advisory-automation/lib/triage-report.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const BANNER = 'TRIAGE PLAN (read-only) — no tickets, PRs, or writes performed.';
+
+/** Render one triage entry; redact non-published advisories when publicSafe. */
+function formatEntry(e, publicSafe) {
+  if (publicSafe && e.state !== 'published') {
+    return `- ${e.ghsaId} [${e.state}] — ${e.outcome}; details suppressed on public runner (non-published). Use the local CLI.`;
+  }
+  if (e.outcome === 'already-handled') return `- ${e.ghsaId} [${e.state}] — already handled (${e.reason})`;
+  if (e.outcome === 'not-applicable') return `- ${e.ghsaId} [${e.state}] — not applicable (${e.reason})`;
+  // actionable
+  const lines = [`- ${e.ghsaId} [${e.state}, severity: ${e.severity}] — ACTIONABLE`];
+  for (const t of e.targets) {
+    const where = t.location
+      ? `${t.location.repo}@${t.location.branch}`
+      : 'HUMAN-FALLBACK (target branch not found in base or ee-* repo)';
+    const lts = t.ltsInScope
+      ? (t.ltsLines.length ? `LTS backport → ${t.ltsLines.join(', ')}` : 'LTS backport in scope (no active LTS lines)')
+      : 'no LTS backport (severity < high)';
+    lines.push(`    ${t.package} → fix on ${where}; ${lts}`);
+  }
+  return lines.join('\n');
+}
+
+function formatTriagePlan(entries, opts = {}) {
+  const publicSafe = opts.publicSafe === true;
+  const body = entries.length
+    ? entries.map((e) => formatEntry(e, publicSafe)).join('\n')
+    : '(no advisories)';
+  return `${BANNER}\n${body}`;
+}
+
+module.exports = { BANNER, formatEntry, formatTriagePlan };

--- a/scripts/security-advisory-automation/lib/triage.js
+++ b/scripts/security-advisory-automation/lib/triage.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { route } = require('./routing');
+
+/**
+ * Classify one parsed advisory into a triage outcome for Workflow 1.
+ *
+ * Pure function: the dedup verdict is supplied as `opts.handled` (computed by an
+ * org-wide artifact search — see `artifactSearchQuery`), so this stays testable
+ * and side-effect-free. It decides *what* should happen; creating the ticket and
+ * dispatching the coding agent is the (write) orchestration layer, not here.
+ *
+ * @param {{ ghsaId: string, state: string, severity: string, summary: string, packages: string[] }} advisory
+ * @param {{ handled?: boolean }} [opts]
+ * @returns {{ ghsaId: string, state: string, outcome: 'already-handled'|'not-applicable'|'actionable', reason?: string, severity?: string, decisions?: object[] }}
+ */
+function classifyAdvisory(advisory, opts = {}) {
+  const base = { ghsaId: advisory.ghsaId, state: advisory.state };
+
+  // Idempotency: an existing open/merged artifact referencing this GHSA id means
+  // it's already ticketed or being handled manually — skip. Takes precedence.
+  if (opts.handled === true) {
+    return {
+      ...base,
+      outcome: 'already-handled',
+      reason: 'an open/merged issue or PR already references this advisory',
+    };
+  }
+
+  const decisions = route(advisory); // one routing decision per composer package
+  if (decisions.length === 0) {
+    return { ...base, outcome: 'not-applicable', reason: 'no composer packages to route' };
+  }
+
+  return { ...base, outcome: 'actionable', severity: advisory.severity, decisions };
+}
+
+/**
+ * Org-wide search query to find any issue/PR that already references an advisory.
+ * The GHSA id is the dedup key and the human-readable traceability link, so a
+ * single query covers both auto-created tickets and manual takeovers. Read-only.
+ *
+ * @param {string} org
+ * @param {string} ghsaId
+ * @returns {string}
+ */
+function artifactSearchQuery(org, ghsaId) {
+  return `org:${org} ${ghsaId} in:title,body`;
+}
+
+module.exports = { classifyAdvisory, artifactSearchQuery };

--- a/scripts/security-advisory-automation/lib/versions-drift.js
+++ b/scripts/security-advisory-automation/lib/versions-drift.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** Parse "2026.1" -> [2026, 1]; returns null if not a YYYY.N line. */
+function parseLine(s) {
+  const m = /^(\d{4})\.(\d+)$/.exec(String(s).trim());
+  return m ? [Number(m[1]), Number(m[2])] : null;
+}
+
+/** >0 if a is newer than b, <0 older, 0 equal. */
+function compareLines(a, b) {
+  const pa = parseLine(a);
+  const pb = parseLine(b);
+  if (!pa || !pb) throw new Error(`not a version line: ${JSON.stringify(!pa ? a : b)}`);
+  return pa[0] - pb[0] || pa[1] - pb[1];
+}
+
+/** Newest YYYY.N token appearing in the fetched page text, or null. */
+function newestLineOnDocs(pageText) {
+  const tokens = String(pageText).match(/\b20\d\d\.\d+\b/g) || [];
+  let newest = null;
+  for (const t of tokens) {
+    if (newest === null || compareLines(t, newest) > 0) newest = t;
+  }
+  return newest;
+}
+
+/** Drift = the docs page shows a line newer than config.activeBugfixLine. */
+function detectNewRelease(config, pageText) {
+  const newest = newestLineOnDocs(pageText);
+  const drifted = newest != null && compareLines(newest, config.activeBugfixLine) > 0;
+  return { newest, active: config.activeBugfixLine, drifted };
+}
+
+module.exports = { parseLine, compareLines, newestLineOnDocs, detectNewRelease };

--- a/scripts/security-advisory-automation/lib/versions-drift.js
+++ b/scripts/security-advisory-automation/lib/versions-drift.js
@@ -31,4 +31,39 @@ function detectNewRelease(config, pageText) {
   return { newest, active: config.activeBugfixLine, drifted };
 }
 
-module.exports = { parseLine, compareLines, newestLineOnDocs, detectNewRelease };
+/**
+ * Evaluate the docs page against the config and return a status the workflow
+ * acts on. Distinguishes "unparseable" (no version line found — the scraper
+ * likely broke) from "ok" so a broken fetch fails LOUD instead of silently
+ * looking like "no drift".
+ * @returns {{ status: 'ok'|'drift'|'unparseable', newest: string|null, active: string, message: string }}
+ */
+function evaluateDrift(config, pageText) {
+  const { newest, active, drifted } = detectNewRelease(config, pageText);
+  if (newest === null) {
+    return {
+      status: 'unparseable',
+      newest,
+      active,
+      message:
+        'Could not find any version line on the docs page — its structure may have ' +
+        'changed, or the fetch failed. The drift-check needs attention (not treated as "no drift").',
+    };
+  }
+  if (drifted) {
+    return {
+      status: 'drift',
+      newest,
+      active,
+      message: `Docs page shows ${newest}, newer than configured activeBugfixLine ${active}. Update config/supported-versions.json (see the page).`,
+    };
+  }
+  return {
+    status: 'ok',
+    newest,
+    active,
+    message: `No new release beyond configured activeBugfixLine ${active} (newest on docs: ${newest}).`,
+  };
+}
+
+module.exports = { parseLine, compareLines, newestLineOnDocs, detectNewRelease, evaluateDrift };

--- a/scripts/security-advisory-automation/lib/versions.js
+++ b/scripts/security-advisory-automation/lib/versions.js
@@ -1,0 +1,24 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_PATH = path.join(__dirname, '..', 'config', 'supported-versions.json');
+
+function loadSupportedVersions(configPath = DEFAULT_PATH) {
+  return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+/** The current release line initial fixes land on. */
+function lowestActiveBugfixLine(config) {
+  return config.activeBugfixLine;
+}
+
+/** LTS lines still within their support window at `now` (severity>=high backport targets). */
+function ltsLinesInScope(config, now) {
+  const at = now instanceof Date ? now : new Date(now);
+  return (config.ltsLines || [])
+    .filter((l) => new Date(l.supportUntil) >= at)
+    .map((l) => l.line);
+}
+
+module.exports = { loadSupportedVersions, lowestActiveBugfixLine, ltsLinesInScope };

--- a/scripts/security-advisory-automation/tests/cli.test.js
+++ b/scripts/security-advisory-automation/tests/cli.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { parseArgs } = require('../cli');
+const { parseArgs, buildGhPath } = require('../cli');
 
 describe('parseArgs', () => {
   it('positional ghsa id', () => {
@@ -10,6 +10,7 @@ describe('parseArgs', () => {
     assert.equal(r.ghsaId, 'GHSA-1234-5678-abcd');
     assert.equal(r.latest, undefined);
     assert.equal(r.repo, 'pimcore/pimcore');
+    assert.equal(r.triage, false);
   });
 
   it('--repo overrides default', () => {
@@ -35,5 +36,53 @@ describe('parseArgs', () => {
     assert.equal(r.repo, 'pimcore/foo');
     assert.equal(r.latest, 3);
     assert.equal(r.ghsaId, undefined);
+  });
+
+  it('--triage sets the triage flag', () => {
+    const r = parseArgs(['--triage']);
+    assert.equal(r.triage, true);
+    assert.equal(r.ghsaId, undefined);
+    assert.equal(r.latest, undefined);
+  });
+
+  it('--triage with --repo and --limit', () => {
+    const r = parseArgs(['--triage', '--repo', 'pimcore/data-hub', '--limit', '10']);
+    assert.equal(r.triage, true);
+    assert.equal(r.repo, 'pimcore/data-hub');
+    assert.equal(r.limit, 10);
+    assert.strictEqual(typeof r.limit, 'number');
+  });
+});
+
+describe('buildGhPath', () => {
+  it('substitutes path params and leaves no query string when none remain', () => {
+    const path = buildGhPath('GET /repos/{owner}/{repo}/branches/{branch}', {
+      owner: 'pimcore',
+      repo: 'pimcore',
+      branch: '2026.1',
+    });
+    assert.equal(path, 'repos/pimcore/pimcore/branches/2026.1');
+  });
+
+  it('turns leftover params into a query string', () => {
+    const path = buildGhPath('GET /repos/{owner}/{repo}/security-advisories', {
+      owner: 'pimcore',
+      repo: 'pimcore',
+      per_page: 30,
+    });
+    assert.equal(path, 'repos/pimcore/pimcore/security-advisories?per_page=30');
+  });
+
+  it('URL-encodes query param values', () => {
+    const path = buildGhPath('GET /search/issues', { q: 'org:pimcore GHSA-xxxx in:title,body' });
+    assert.equal(path, 'search/issues?q=org%3Apimcore%20GHSA-xxxx%20in%3Atitle%2Cbody');
+  });
+
+  it('rejects non-GET routes (read-only shim)', () => {
+    assert.throws(() => buildGhPath('POST /repos/{owner}/{repo}/issues', { owner: 'a', repo: 'b' }), /read-only/);
+  });
+
+  it('throws when a required path param is missing', () => {
+    assert.throws(() => buildGhPath('GET /repos/{owner}/{repo}/branches/{branch}', { owner: 'a', repo: 'b' }), /missing param/);
   });
 });

--- a/scripts/security-advisory-automation/tests/orchestrate.test.js
+++ b/scripts/security-advisory-automation/tests/orchestrate.test.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  runTriage,
+  resolveFixLocation,
+  branchExists,
+  searchHandled,
+} = require('../lib/orchestrate');
+
+const NOW = new Date('2026-07-03');
+
+// Fixtures in the raw GitHub repository-security-advisory API shape.
+const rawPublishedCritical = {
+  ghsa_id: 'GHSA-1111-1111-1111',
+  state: 'published',
+  severity: 'critical',
+  summary: 'Critical issue in data-hub',
+  vulnerabilities: [{ package: { ecosystem: 'composer', name: 'pimcore/data-hub' } }],
+};
+const rawTriageHigh = {
+  ghsa_id: 'GHSA-2222-2222-2222',
+  state: 'triage',
+  severity: 'high',
+  summary: 'High issue in pimcore core, still in triage',
+  vulnerabilities: [{ package: { ecosystem: 'composer', name: 'pimcore/pimcore' } }],
+};
+const rawClosedLowNoComposer = {
+  ghsa_id: 'GHSA-3333-3333-3333',
+  state: 'closed',
+  severity: 'low',
+  summary: 'Low severity, npm-only advisory',
+  vulnerabilities: [{ package: { ecosystem: 'npm', name: 'some-js-package' } }],
+};
+
+/**
+ * A fake octokit whose .request() only ever answers the three GET routes
+ * runTriage uses. Every branch of this fake is a read; nothing mutates.
+ */
+function makeFakeGithub({ handledGhsaIds = new Set(), branchMap = {} } = {}) {
+  return {
+    request: async (route, params) => {
+      if (route === 'GET /repos/{owner}/{repo}/security-advisories') {
+        return { data: [rawPublishedCritical, rawTriageHigh, rawClosedLowNoComposer] };
+      }
+      if (route === 'GET /search/issues') {
+        const handled = [...handledGhsaIds].some((id) => params.q.includes(id));
+        return { data: { total_count: handled ? 1 : 0 } };
+      }
+      if (route === 'GET /repos/{owner}/{repo}/branches/{branch}') {
+        const key = `${params.owner}/${params.repo}@${params.branch}`;
+        if (branchMap[key]) return { data: {} };
+        const err = new Error('Not Found');
+        err.status = 404;
+        throw err;
+      }
+      throw new Error(`unexpected route in fake github: ${route} ${JSON.stringify(params)}`);
+    },
+  };
+}
+
+describe('runTriage', () => {
+  it('classifies published/triage/closed advisories and resolves branches (base + ee fallback)', async () => {
+    const github = makeFakeGithub({
+      branchMap: {
+        'pimcore/data-hub@2026.1': true, // base has it
+        // pimcore/pimcore@2026.1 absent -> falls back to ee-pimcore
+        'pimcore/ee-pimcore@2026.1': true,
+      },
+    });
+
+    const entries = await runTriage({
+      github,
+      sourceRepo: 'pimcore/pimcore',
+      now: NOW,
+      publicSafe: false,
+      log: () => {},
+    });
+
+    assert.equal(entries.length, 3);
+
+    const [dataHubEntry, pimcoreEntry, closedEntry] = entries;
+
+    assert.equal(dataHubEntry.ghsaId, 'GHSA-1111-1111-1111');
+    assert.equal(dataHubEntry.outcome, 'actionable');
+    assert.equal(dataHubEntry.severity, 'critical');
+    assert.equal(dataHubEntry.targets.length, 1);
+    assert.deepEqual(dataHubEntry.targets[0].location, { repo: 'pimcore/data-hub', branch: '2026.1' });
+    assert.equal(dataHubEntry.targets[0].ltsInScope, true);
+    assert.ok(dataHubEntry.targets[0].ltsLines.includes('2025.4'));
+
+    assert.equal(pimcoreEntry.ghsaId, 'GHSA-2222-2222-2222');
+    assert.equal(pimcoreEntry.outcome, 'actionable');
+    assert.deepEqual(pimcoreEntry.targets[0].location, { repo: 'pimcore/ee-pimcore', branch: '2026.1' });
+
+    assert.equal(closedEntry.ghsaId, 'GHSA-3333-3333-3333');
+    assert.equal(closedEntry.outcome, 'not-applicable');
+    assert.equal(closedEntry.reason, 'no composer packages to route');
+    assert.equal(closedEntry.targets.length, 0);
+  });
+
+  it('marks an advisory already-handled when the org search finds an existing artifact', async () => {
+    const github = makeFakeGithub({
+      handledGhsaIds: new Set(['GHSA-1111-1111-1111']),
+      branchMap: { 'pimcore/data-hub@2026.1': true, 'pimcore/ee-pimcore@2026.1': true },
+    });
+
+    const entries = await runTriage({
+      github,
+      sourceRepo: 'pimcore/pimcore',
+      now: NOW,
+      publicSafe: false,
+      log: () => {},
+    });
+
+    const dataHubEntry = entries.find((e) => e.ghsaId === 'GHSA-1111-1111-1111');
+    assert.equal(dataHubEntry.outcome, 'already-handled');
+    assert.match(dataHubEntry.reason, /already references/);
+  });
+
+  it('only ever issues GET requests', async () => {
+    const methods = new Set();
+    const github = {
+      request: async (route, params) => {
+        methods.add(route.split(' ')[0]);
+        if (route === 'GET /repos/{owner}/{repo}/security-advisories') {
+          return { data: [rawPublishedCritical] };
+        }
+        if (route === 'GET /search/issues') return { data: { total_count: 0 } };
+        if (route === 'GET /repos/{owner}/{repo}/branches/{branch}') return { data: {} };
+        throw new Error(`unexpected route ${route}`);
+      },
+    };
+    await runTriage({ github, sourceRepo: 'pimcore/pimcore', now: NOW, log: () => {} });
+    assert.deepEqual([...methods], ['GET']);
+  });
+});
+
+describe('searchHandled', () => {
+  it('maps total_count > 0 to handled=true', async () => {
+    const github = { request: async () => ({ data: { total_count: 2 } }) };
+    assert.equal(await searchHandled(github, 'pimcore', 'GHSA-xxxx-xxxx-xxxx'), true);
+  });
+
+  it('maps total_count === 0 to handled=false', async () => {
+    const github = { request: async () => ({ data: { total_count: 0 } }) };
+    assert.equal(await searchHandled(github, 'pimcore', 'GHSA-xxxx-xxxx-xxxx'), false);
+  });
+});
+
+describe('branchExists', () => {
+  it('resolves true when the branch is found', async () => {
+    const github = { request: async () => ({ data: {} }) };
+    assert.equal(await branchExists(github, 'pimcore/pimcore', '2026.1'), true);
+  });
+
+  it('resolves false on a 404', async () => {
+    const github = {
+      request: async () => {
+        const err = new Error('Not Found');
+        err.status = 404;
+        throw err;
+      },
+    };
+    assert.equal(await branchExists(github, 'pimcore/pimcore', '2026.1'), false);
+  });
+
+  it('rethrows non-404 errors', async () => {
+    const github = {
+      request: async () => {
+        const err = new Error('Forbidden');
+        err.status = 403;
+        throw err;
+      },
+    };
+    await assert.rejects(branchExists(github, 'pimcore/pimcore', '2026.1'), /Forbidden/);
+  });
+});
+
+describe('resolveFixLocation', () => {
+  it('returns the base repo when the branch exists there', async () => {
+    const github = { request: async () => ({ data: {} }) };
+    const loc = await resolveFixLocation(github, 'pimcore/pimcore', '2026.1');
+    assert.deepEqual(loc, { repo: 'pimcore/pimcore', branch: '2026.1' });
+  });
+
+  it('falls back to the ee-* repo when only it has the branch', async () => {
+    const github = {
+      request: async (route, params) => {
+        if (params.repo === 'pimcore') {
+          const err = new Error('Not Found');
+          err.status = 404;
+          throw err;
+        }
+        return { data: {} }; // ee-pimcore has it
+      },
+    };
+    const loc = await resolveFixLocation(github, 'pimcore/pimcore', '2026.1');
+    assert.deepEqual(loc, { repo: 'pimcore/ee-pimcore', branch: '2026.1' });
+  });
+
+  it('returns null (human-fallback) when neither base nor ee has the branch', async () => {
+    const github = {
+      request: async () => {
+        const err = new Error('Not Found');
+        err.status = 404;
+        throw err;
+      },
+    };
+    const loc = await resolveFixLocation(github, 'pimcore/pimcore', '2026.1');
+    assert.equal(loc, null);
+  });
+});

--- a/scripts/security-advisory-automation/tests/triage-report.test.js
+++ b/scripts/security-advisory-automation/tests/triage-report.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { BANNER, formatTriagePlan } = require('../lib/triage-report');
+
+const actionablePublished = {
+  ghsaId: 'GHSA-1111-1111-1111',
+  state: 'published',
+  outcome: 'actionable',
+  severity: 'critical',
+  targets: [
+    {
+      package: 'pimcore/data-hub',
+      fixRepo: 'pimcore/data-hub',
+      location: { repo: 'pimcore/data-hub', branch: '2026.1' },
+      ltsInScope: true,
+      ltsLines: ['2025.4', '2024.4'],
+    },
+  ],
+};
+
+const actionableTriage = {
+  ghsaId: 'GHSA-2222-2222-2222',
+  state: 'triage',
+  outcome: 'actionable',
+  severity: 'high',
+  targets: [
+    {
+      package: 'pimcore/pimcore',
+      fixRepo: 'pimcore/pimcore',
+      location: { repo: 'pimcore/ee-pimcore', branch: '2026.1' },
+      ltsInScope: true,
+      ltsLines: ['2025.4'],
+    },
+  ],
+};
+
+const notApplicable = {
+  ghsaId: 'GHSA-3333-3333-3333',
+  state: 'closed',
+  outcome: 'not-applicable',
+  reason: 'no composer packages to route',
+  targets: [],
+};
+
+const alreadyHandled = {
+  ghsaId: 'GHSA-4444-4444-4444',
+  state: 'published',
+  outcome: 'already-handled',
+  reason: 'an open/merged issue or PR already references this advisory',
+  targets: [],
+};
+
+const humanFallback = {
+  ghsaId: 'GHSA-5555-5555-5555',
+  state: 'published',
+  outcome: 'actionable',
+  severity: 'high',
+  targets: [
+    {
+      package: 'pimcore/some-bundle',
+      fixRepo: 'pimcore/some-bundle',
+      location: null,
+      ltsInScope: true,
+      ltsLines: [],
+    },
+  ],
+};
+
+describe('formatTriagePlan', () => {
+  it('always includes the read-only banner', () => {
+    const out = formatTriagePlan([], { publicSafe: true });
+    assert.ok(out.includes(BANNER));
+    assert.ok(out.includes('(no advisories)'));
+  });
+
+  it('an actionable published entry shows the fix location and LTS lines', () => {
+    const out = formatTriagePlan([actionablePublished], { publicSafe: false });
+    assert.ok(out.includes('ACTIONABLE'));
+    assert.ok(out.includes('fix on pimcore/data-hub@2026.1'));
+    assert.ok(out.includes('LTS backport → 2025.4, 2024.4'));
+  });
+
+  it('a not-applicable entry shows its reason', () => {
+    const out = formatTriagePlan([notApplicable], { publicSafe: false });
+    assert.ok(out.includes('not applicable (no composer packages to route)'));
+  });
+
+  it('an already-handled entry shows its reason', () => {
+    const out = formatTriagePlan([alreadyHandled], { publicSafe: false });
+    assert.ok(out.includes('already handled (an open/merged issue or PR already references this advisory)'));
+  });
+
+  it('an actionable entry with no resolvable branch shows HUMAN-FALLBACK', () => {
+    const out = formatTriagePlan([humanFallback], { publicSafe: false });
+    assert.ok(out.includes('HUMAN-FALLBACK'));
+  });
+
+  it('under publicSafe, a non-published (triage) entry is redacted', () => {
+    const out = formatTriagePlan([actionableTriage], { publicSafe: true });
+    assert.ok(out.includes('details suppressed'));
+    assert.ok(!out.includes('high'), 'severity must not leak');
+    assert.ok(!out.includes('pimcore/pimcore'), 'package must not leak');
+    assert.ok(!out.includes('ee-pimcore'), 'fixRepo/location must not leak');
+    assert.ok(!out.includes('ACTIONABLE'));
+  });
+
+  it('under publicSafe, a published entry still renders in full', () => {
+    const out = formatTriagePlan([actionablePublished], { publicSafe: true });
+    assert.ok(!out.includes('details suppressed'));
+    assert.ok(out.includes('ACTIONABLE'));
+    assert.ok(out.includes('pimcore/data-hub'));
+  });
+
+  it('defaults to publicSafe=false when opts is omitted', () => {
+    const out = formatTriagePlan([actionableTriage]);
+    assert.ok(!out.includes('details suppressed'));
+    assert.ok(out.includes('ACTIONABLE'));
+  });
+});

--- a/scripts/security-advisory-automation/tests/triage.test.js
+++ b/scripts/security-advisory-automation/tests/triage.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { classifyAdvisory, artifactSearchQuery } = require('../lib/triage');
+
+function adv(over = {}) {
+  return {
+    ghsaId: 'GHSA-34vf-ww58-w3wc',
+    state: 'triage',
+    severity: 'critical',
+    summary: 'x',
+    packages: ['pimcore/admin-ui-classic-bundle'],
+    ...over,
+  };
+}
+
+test('classifyAdvisory: handled → already-handled (skip)', () => {
+  const r = classifyAdvisory(adv(), { handled: true });
+  assert.equal(r.outcome, 'already-handled');
+  assert.equal(r.ghsaId, 'GHSA-34vf-ww58-w3wc');
+  assert.ok(!r.decisions, 'no routing decisions when skipped');
+});
+
+test('classifyAdvisory: no composer packages → not-applicable', () => {
+  const r = classifyAdvisory(adv({ packages: [] }));
+  assert.equal(r.outcome, 'not-applicable');
+});
+
+test('classifyAdvisory: composer package → actionable with routing decisions', () => {
+  const r = classifyAdvisory(adv());
+  assert.equal(r.outcome, 'actionable');
+  assert.equal(r.severity, 'critical');
+  assert.equal(r.decisions.length, 1);
+  assert.equal(r.decisions[0].fixRepo, 'pimcore/admin-ui-classic-bundle');
+  assert.equal(r.decisions[0].eeRepo, 'pimcore/ee-admin-ui-classic-bundle');
+});
+
+test('classifyAdvisory: handled takes precedence over routing', () => {
+  const r = classifyAdvisory(adv({ packages: ['pimcore/data-hub'] }), { handled: true });
+  assert.equal(r.outcome, 'already-handled');
+});
+
+test('classifyAdvisory: carries advisory state through', () => {
+  assert.equal(classifyAdvisory(adv({ state: 'published' })).state, 'published');
+});
+
+test('artifactSearchQuery: org-scoped GHSA-id search over title+body', () => {
+  assert.equal(
+    artifactSearchQuery('pimcore', 'GHSA-34vf-ww58-w3wc'),
+    'org:pimcore GHSA-34vf-ww58-w3wc in:title,body'
+  );
+});

--- a/scripts/security-advisory-automation/tests/versions-drift.test.js
+++ b/scripts/security-advisory-automation/tests/versions-drift.test.js
@@ -8,6 +8,7 @@ const {
   compareLines,
   newestLineOnDocs,
   detectNewRelease,
+  evaluateDrift,
 } = require('../lib/versions-drift');
 
 // compareLines
@@ -52,4 +53,34 @@ test('detectNewRelease: drift when docs show a newer line than configured', () =
   const result = detectNewRelease(config, 'now shows 2026.2 as current');
   assert.equal(result.drifted, true);
   assert.equal(result.newest, '2026.2');
+});
+
+// compareLines / newestLineOnDocs: double-digit minor must sort numerically, not lexically
+test('compareLines: 2026.10 is newer than 2026.2 (numeric, not lexical)', () => {
+  assert.ok(compareLines('2026.10', '2026.2') > 0);
+});
+
+test('newestLineOnDocs: picks 2026.10 over 2026.2 (numeric)', () => {
+  assert.equal(newestLineOnDocs('rows: 2026.2 2026.10 2025.4'), '2026.10');
+});
+
+// evaluateDrift: ok / drift / unparseable (fail-loud)
+test('evaluateDrift: ok when newest matches active line', () => {
+  const config = loadSupportedVersions();
+  const r = evaluateDrift(config, 'page lists 2026.1 2025.4 2024.4');
+  assert.equal(r.status, 'ok');
+});
+
+test('evaluateDrift: drift when a newer line appears', () => {
+  const config = loadSupportedVersions();
+  const r = evaluateDrift(config, 'shows 2026.2');
+  assert.equal(r.status, 'drift');
+  assert.equal(r.newest, '2026.2');
+});
+
+test('evaluateDrift: unparseable page fails loud (not treated as no-drift)', () => {
+  const config = loadSupportedVersions();
+  const r = evaluateDrift(config, '<html>docs redesigned, no version lines here</html>');
+  assert.equal(r.status, 'unparseable');
+  assert.match(r.message, /needs attention/);
 });

--- a/scripts/security-advisory-automation/tests/versions-drift.test.js
+++ b/scripts/security-advisory-automation/tests/versions-drift.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { loadSupportedVersions } = require('../lib/versions');
+const {
+  parseLine,
+  compareLines,
+  newestLineOnDocs,
+  detectNewRelease,
+} = require('../lib/versions-drift');
+
+// compareLines
+test('compareLines: 2026.2 is newer than 2026.1', () => {
+  assert.ok(compareLines('2026.2', '2026.1') > 0);
+});
+
+test('compareLines: 2026.1 is newer than 2025.4', () => {
+  assert.ok(compareLines('2026.1', '2025.4') > 0);
+});
+
+test('compareLines: 2026.1 equals 2026.1', () => {
+  assert.equal(compareLines('2026.1', '2026.1'), 0);
+});
+
+test('compareLines: throws on non version-line input', () => {
+  assert.throws(() => compareLines('x', '2026.1'), Error);
+});
+
+// parseLine
+test('parseLine: returns null for non version-line input', () => {
+  assert.equal(parseLine('nope'), null);
+});
+
+// newestLineOnDocs
+test('newestLineOnDocs: picks the newest token among several', () => {
+  assert.equal(
+    newestLineOnDocs('… 2024.4 … 2026.1 … 2025.4 …'),
+    '2026.1'
+  );
+});
+
+// detectNewRelease
+test('detectNewRelease: no drift when docs newest equals configured active line', () => {
+  const config = loadSupportedVersions();
+  const result = detectNewRelease(config, 'page lists 2026.1 2025.4 2024.4');
+  assert.equal(result.drifted, false);
+});
+
+test('detectNewRelease: drift when docs show a newer line than configured', () => {
+  const config = loadSupportedVersions();
+  const result = detectNewRelease(config, 'now shows 2026.2 as current');
+  assert.equal(result.drifted, true);
+  assert.equal(result.newest, '2026.2');
+});

--- a/scripts/security-advisory-automation/tests/versions.test.js
+++ b/scripts/security-advisory-automation/tests/versions.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  loadSupportedVersions,
+  lowestActiveBugfixLine,
+  ltsLinesInScope,
+} = require('../lib/versions');
+
+test('loadSupportedVersions: loads default config with activeBugfixLine 2026.1', () => {
+  const config = loadSupportedVersions();
+  assert.equal(config.activeBugfixLine, '2026.1');
+});
+
+test('lowestActiveBugfixLine: returns 2026.1', () => {
+  const config = loadSupportedVersions();
+  assert.equal(lowestActiveBugfixLine(config), '2026.1');
+});
+
+test('ltsLinesInScope: at 2026-07-03 excludes lines whose support already ended', () => {
+  const config = loadSupportedVersions();
+  assert.deepEqual(
+    ltsLinesInScope(config, new Date('2026-07-03')),
+    ['2025.4', '2024.4']
+  );
+});
+
+test('ltsLinesInScope: at 2024-01-01 includes all four lines', () => {
+  const config = loadSupportedVersions();
+  assert.deepEqual(
+    ltsLinesInScope(config, new Date('2024-01-01')),
+    ['2025.4', '2024.4', '2023.3', '2022.0']
+  );
+});


### PR DESCRIPTION
## What this adds

**Workflow 1 in read-only "plan mode"** — the decision core of the triage-and-dispatch automation, with **no writes** (every GitHub call is a GET). It answers: *for the recent advisories, what would the automation do?*

> **Stacked on #112** (base branch = `feat/security-advisory-automation`). Review/merge #112 first; this PR shows only the 4 triage commits. Retarget to `main` once #112 lands.

### Pieces
- **Triage classification** (`lib/triage.js`) — `already-handled` (dedup) / `not-applicable` / `actionable`, reusing the routing config layer.
- **Dedup** — org-wide issue/PR search for the GHSA id (the traceability key), so auto-created tickets *and* manual takeovers both count as handled.
- **Supported-versions source** (`config/supported-versions.json`) — mirrored from the [Platform Versions doc page](https://docs.pimcore.com/platform/Pimcore_Platform/Platform_Versions/) (the page has no machine-readable form), with `lowestActiveBugfixLine` (initial-fix target) and date-filtered `ltsLinesInScope` (the severity-≥-high backport targets).
- **Drift-check** (`.github/workflows/advisory-versions-drift.yml`, read-only) — weekly, flags when the docs page shows a newer release than the config; **fails loud** if the page can't be parsed (a broken scraper can't masquerade as "no drift").
- **Orchestration** (`lib/orchestrate.js`) — `runTriage`: fetch → dedup → classify → for actionable advisories, resolve the initial-fix location (base repo, else its `ee-*` counterpart via a branch-existence check, else human-fallback) and the in-scope LTS lines.
- **Interfaces** — local CLI `node cli.js --triage [--repo] [--limit N]` (full detail, via a GET-only `gh` shim) and an `Advisory Triage` `workflow_dispatch` workflow (octokit, `publicSafe`-redacted for the public log).

### Verified live (read-only)
```
TRIAGE PLAN (read-only) — no tickets, PRs, or writes performed.
- GHSA-h68g-m8xh-vwm6 [triage, severity: high] — ACTIONABLE
    pimcore/pimcore → fix on pimcore/pimcore@2026.1; LTS backport → 2025.4, 2024.4
```
LTS lines correctly filtered to the in-scope set (`2023.3`/`2022.0` expired, excluded).

## Safety
- **Strictly read-only.** GET-only octokit/`gh` calls; the CLI shim refuses non-GET routes; both workflows are `permissions: contents: read, security-events: read`.
- **Public-log disclosure guard** carried over: non-`published` advisories are redacted in CI (`publicSafe`); full detail only via the local CLI.
- **139 `node:test` cases**, all green (incl. fake-github orchestration tests + a "GET requests only" assertion).

## Not in this PR (deliberately deferred)
The **write** side — creating the ticket + assigning `copilot-swe-agent` + Teams notification (Workflow 1 dispatch), and all of **Workflow 2** (forward-merge + LTS backport) — is gated on: a cross-repo token (GitHub App / read+write PAT), a Teams webhook secret, and the one remaining spike item (does the coding agent honor a non-default base branch).

## Minor follow-ups (non-blocking, from review)
- `runTriage` doesn't yet translate 401/403 into the friendly `ADVISORY_READ_TOKEN` hint that `runDryRun` gives (raw error surfaces instead).
- If an `ADVISORY_READ_TOKEN` PAT is added, it should itself be **read-scoped** — the workflow `permissions:` block doesn't constrain a PAT.
- `searchHandled` runs before the not-applicable check (one extra search for package-less advisories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
