### PR TITLE
Scope private-Packagist token to install step in copilot-setup-steps

### DIFF
--- a/.github/sync-templates/copilot-setup-steps.yml
+++ b/.github/sync-templates/copilot-setup-steps.yml
@@ -31,13 +31,18 @@ jobs:
         with:
           php-version: "8.4"
 
-      - name: "Add authentication for private pimcore packages"
+      - name: "Configure private pimcore package repository"
         run: |
           composer config repositories.private-packagist '{"type": "composer", "url": "https://repo.pimcore.com/github-actions/", "canonical": true}'
-          composer config --global --auth http-basic.repo.pimcore.com github-actions ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
+        # Pass the private-Packagist token via a step-scoped env var instead of
+        # writing it to Composer's global auth.json. A global credential would
+        # persist on the runner filesystem and remain readable by the Copilot
+        # coding agent after setup; COMPOSER_AUTH lives only for this step.
+        env:
+          COMPOSER_AUTH: '{"http-basic":{"repo.pimcore.com":{"username":"github-actions","password":"${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}"}}}'
         with:
           composer-options: "--no-scripts --ignore-platform-reqs"
 


### PR DESCRIPTION
## What

Stop writing the private-Packagist token into Composer's **global `auth.json`** in the `copilot-setup-steps` template. Provide it via a **step-scoped `COMPOSER_AUTH` env var** on the install step instead.

## Why

`composer config --global --auth` writes the token to `$COMPOSER_HOME/auth.json`, which persists on the runner filesystem. Because `copilot-setup-steps` produces the environment the Copilot coding agent runs in, the token stayed readable by the agent (and any code it executes) after setup — defeating the intent that setup secrets not reach the agent.

A step-scoped `COMPOSER_AUTH` env var exists only for the install step's process: it is not exported to `$GITHUB_ENV`, not written to disk, and out of scope once the step finishes. The HTTPS-Packagist approach is unchanged (no SSH).

## Scope

This is the **source template** (`.github/sync-templates/copilot-setup-steps.yml`) synced to all consumer repos, so the fix propagates on the next sync. Raised by Copilot review on the per-repo sync PRs (e.g. `data-quality-management-bundle#315`, `portal-engine#927`), where it was also applied directly as a stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #124