### PR TITLE
Switch to fail on auto merge error

### DIFF
--- a/.github/workflows/reusable-sync-changes.yaml
+++ b/.github/workflows/reusable-sync-changes.yaml
@@ -179,4 +179,5 @@ jobs:
 
             if [[ $SET_LABEL -ne 200 ]]; then
             echo "Failed to merge PR. Please try manually..."
+            exit 1
             fi

--- a/.github/workflows/reusable-sync-changes.yaml
+++ b/.github/workflows/reusable-sync-changes.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Auto merge PR 
         if: steps.diff-check.outputs.DIFF == 'true' && env.AUTO_MERGE == 'true'
-        continue-on-error: true
+        continue-on-error: false
         run: |
             # Auto merge PR
 


### PR DESCRIPTION
This pull request makes a small but important change to the `.github/workflows/reusable-sync-changes.yaml` file, updating the behavior of the auto-merge step in the workflow. The change ensures that the workflow will now fail if the auto-merge step encounters an error, rather than continuing on error.

- Changed the `continue-on-error` property from `true` to `false` for the "Auto merge PR" step, so that the workflow fails if auto-merge does not succeed.