### PR TITLE
Frontend workflows: optional api-client + test jobs, per-branch canary tags

### DIFF
--- a/.github/workflows/reusable-frontend-publish-unified.yaml
+++ b/.github/workflows/reusable-frontend-publish-unified.yaml
@@ -159,6 +159,11 @@ jobs:
       - name: Determine version and tag
         id: version
         shell: bash
+        # Caller inputs are passed via env (not interpolated into the script) so
+        # a malicious caller of this public reusable workflow can't inject shell.
+        env:
+          TARGET_RELEASE: ${{ inputs.target-release }}
+          CANARY_TAG: ${{ inputs.canary-tag }}
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
@@ -169,10 +174,9 @@ jobs:
               TAG="latest"
             fi
           else
-            BASE="${{ inputs.target-release }}"
-            BASE="${BASE%%-*}"
+            BASE="${TARGET_RELEASE%%-*}"
             VERSION="${BASE}-canary.$(date +'%Y%m%d-%H%M%S')-$(git rev-parse --short=7 HEAD)"
-            TAG="${{ inputs.canary-tag }}"
+            TAG="${CANARY_TAG}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
@@ -185,10 +189,14 @@ jobs:
 
       - name: Set package version
         working-directory: ${{ inputs.working-directory }}
-        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         working-directory: ${{ inputs.working-directory }}
-        run: npx npm@${{ inputs.npm-cli-version }} publish --provenance --tag "${{ steps.version.outputs.tag }}" --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISH_TAG: ${{ steps.version.outputs.tag }}
+          NPM_CLI_VERSION: ${{ inputs.npm-cli-version }}
+        run: npx "npm@${NPM_CLI_VERSION}" publish --provenance --tag "$PUBLISH_TAG" --access public

--- a/.github/workflows/reusable-frontend-publish-unified.yaml
+++ b/.github/workflows/reusable-frontend-publish-unified.yaml
@@ -42,6 +42,26 @@ on:
         required: false
         type: string
         default: "build"
+      api-client:
+        description: "Regenerate the API client (before lint/typecheck/build) and commit it"
+        required: false
+        type: boolean
+        default: false
+      api-client-script:
+        description: "NPM script to run for API client generation"
+        required: false
+        type: string
+        default: "build-api-client"
+      test:
+        description: "Run tests after build"
+        required: false
+        type: boolean
+        default: false
+      test-script:
+        description: "NPM script to run for tests"
+        required: false
+        type: string
+        default: "test"
       commit-lint-output:
         description: "Automatically commit lint fixes"
         required: false
@@ -67,6 +87,16 @@ on:
         required: false
         type: string
         default: ""
+      canary-tag:
+        description: "npm dist-tag for canary publishes (e.g. 'canary' or a per-branch 'canary-2026.2')"
+        required: false
+        type: string
+        default: "canary"
+      npm-cli-version:
+        description: "npm CLI version used for `npx npm@<version> publish` (e.g. 'latest' or '11')"
+        required: false
+        type: string
+        default: "latest"
     secrets:
       NPM_TOKEN:
         required: false
@@ -92,6 +122,10 @@ jobs:
       lint-script: ${{ inputs.lint-script }}
       typecheck-script: ${{ inputs.typecheck-script }}
       build-script: ${{ inputs.build-script }}
+      api-client: ${{ inputs.api-client }}
+      api-client-script: ${{ inputs.api-client-script }}
+      test: ${{ inputs.test }}
+      test-script: ${{ inputs.test-script }}
       commit-lint-output: ${{ inputs.commit-lint-output }}
       commit-build-output: ${{ inputs.commit-build-output }}
       build-output-path: ${{ inputs.build-output-path }}
@@ -138,7 +172,7 @@ jobs:
             BASE="${{ inputs.target-release }}"
             BASE="${BASE%%-*}"
             VERSION="${BASE}-canary.$(date +'%Y%m%d-%H%M%S')-$(git rev-parse --short=7 HEAD)"
-            TAG="canary"
+            TAG="${{ inputs.canary-tag }}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
@@ -155,6 +189,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: ${{ inputs.working-directory }}
-        run: npx npm@latest publish --provenance --tag "${{ steps.version.outputs.tag }}" --access public
+        run: npx npm@${{ inputs.npm-cli-version }} publish --provenance --tag "${{ steps.version.outputs.tag }}" --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -38,6 +38,26 @@ on:
         required: false
         type: string
         default: "build"
+      api-client:
+        description: "Regenerate the API client (before lint/typecheck/build) and commit it"
+        required: false
+        type: boolean
+        default: false
+      api-client-script:
+        description: "NPM script to run for API client generation"
+        required: false
+        type: string
+        default: "build-api-client"
+      test:
+        description: "Run tests after build"
+        required: false
+        type: boolean
+        default: false
+      test-script:
+        description: "NPM script to run for tests"
+        required: false
+        type: string
+        default: "test"
       commit-lint-output:
         description: "Automatically commit lint fixes"
         required: false
@@ -78,10 +98,108 @@ env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
+  # Read-only: regenerates the API client (repo-provided code) from the committed
+  # OpenAPI spec and captures the result as a patch artifact. Runs before
+  # lint/typecheck/build so those operate on the freshly generated client. The
+  # write token is NOT present here.
+  api-client:
+    if: ${{ inputs.api-client && !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.capture.outputs.has_changes }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Runs repo-provided code (npm hooks + api-client script); no
+          # authenticated git needed after checkout.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Regenerate API client
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run ${{ inputs.api-client-script }}
+
+      - name: Capture API client changes as a patch
+        id: capture
+        run: |
+          set -euo pipefail
+          # Stage everything (adds, modifications AND deletions) so the patch is
+          # a faithful round-trip, then diff --cached.
+          git add -A
+          git diff --cached --binary > "${RUNNER_TEMP}/api-client.patch"
+          if [[ -s "${RUNNER_TEMP}/api-client.patch" ]]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload API client patch
+        if: ${{ steps.capture.outputs.has_changes == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-client-patch
+          path: ${{ runner.temp }}/api-client.patch
+          retention-days: 1
+          if-no-files-found: error
+          # v4 artifact names are immutable per run; allow re-running failed
+          # jobs to re-upload instead of 409-ing on the second attempt.
+          overwrite: true
+
+  # Write-capable, but runs NO repo-provided code: it only applies the API client
+  # patch and commits it. Gated to non-fork contexts.
+  commit-api-client:
+    needs: api-client
+    if: ${{ inputs.api-client && needs.api-client.outputs.has_changes == 'true' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+          repository: ${{ github.repository }}
+
+      - name: Download API client patch
+        uses: actions/download-artifact@v4
+        with:
+          name: api-client-patch
+          path: ${{ runner.temp }}
+
+      - name: Apply API client changes
+        run: git apply "${RUNNER_TEMP}/api-client.patch"
+
+      - name: Commit API client changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          commit_message: Apply latest automatic api client updates
+
   # Read-only: executes repo-provided code (npm hooks + lint script). Captures
   # any lint fixes as a patch artifact; the write token is NOT present here.
   lint:
-    if: ${{ inputs.lint && !startsWith(github.ref, 'refs/tags/') }}
+    # Ordered after commit-api-client so the checkout includes the freshly
+    # committed client; api-client is also listed so a generation failure blocks
+    # lint rather than letting it run against a stale client. Both default to
+    # `skipped` (api-client off), leaving existing consumers unaffected.
+    needs:
+      - api-client
+      - commit-api-client
+    if: ${{ always() && inputs.lint && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.capture.outputs.has_changes }}
@@ -172,7 +290,13 @@ jobs:
           commit_message: Apply eslint-fixer changes
 
   check-types:
-    if: ${{ inputs.typecheck && !startsWith(github.ref, 'refs/tags/') }}
+    # See lint: ordered after the API client regeneration so type checks run
+    # against the freshly committed client. Skipped deps => no-op when api-client
+    # is off.
+    needs:
+      - api-client
+      - commit-api-client
+    if: ${{ always() && inputs.typecheck && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -211,10 +335,12 @@ jobs:
     # AND when lint failed, so it can't distinguish the two — a direct check on
     # lint.result is what actually blocks the build on a lint failure.
     needs:
+      - api-client
+      - commit-api-client
       - lint
       - commit-lint
       - check-types
-    if: ${{ always() && !startsWith(github.ref, 'refs/tags/') && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.commit-lint.result == 'success' || needs.commit-lint.result == 'skipped') && (needs.check-types.result == 'success' || needs.check-types.result == 'skipped') }}
+    if: ${{ always() && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.commit-lint.result == 'success' || needs.commit-lint.result == 'skipped') && (needs.check-types.result == 'success' || needs.check-types.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.capture.outputs.has_changes }}
@@ -306,3 +432,35 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           file_pattern: ${{ inputs.build-output-path }}
           commit_message: Automatic frontend build
+
+  # Read-only: runs the repo's test script after the build (and after any build
+  # output has been committed). No write token here.
+  test:
+    needs:
+      - build
+      - commit-build
+    if: ${{ always() && inputs.test && !startsWith(github.ref, 'refs/tags/') && needs.build.result == 'success' && (needs.commit-build.result == 'success' || needs.commit-build.result == 'skipped') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Runs repo-provided code (npm hooks + test script); no authenticated
+          # git needed after checkout.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Run tests
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run ${{ inputs.test-script }}

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -187,6 +187,9 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: ${{ env.BRANCH_NAME }}
+          # Rebase onto the remote tip before pushing so a concurrent push to the
+          # same branch doesn't fail this with a non-fast-forward rejection.
+          pull: "--rebase --autostash"
           commit_message: Apply latest automatic api client updates
 
   # Read-only: executes repo-provided code (npm hooks + lint script). Captures
@@ -287,6 +290,9 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: ${{ env.BRANCH_NAME }}
+          # Rebase onto the remote tip before pushing so a concurrent push to the
+          # same branch doesn't fail this with a non-fast-forward rejection.
+          pull: "--rebase --autostash"
           commit_message: Apply eslint-fixer changes
 
   check-types:
@@ -431,6 +437,9 @@ jobs:
         with:
           branch: ${{ env.BRANCH_NAME }}
           file_pattern: ${{ inputs.build-output-path }}
+          # Rebase onto the remote tip before pushing so a concurrent push to the
+          # same branch doesn't fail this with a non-fast-forward rejection.
+          pull: "--rebase --autostash"
           commit_message: Automatic frontend build
 
   # Read-only: runs the repo's test script after the build (and after any build

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -202,7 +202,7 @@ jobs:
     needs:
       - api-client
       - commit-api-client
-    if: ${{ always() && inputs.lint && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') }}
+    if: ${{ !cancelled() && inputs.lint && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.capture.outputs.has_changes }}
@@ -302,7 +302,7 @@ jobs:
     needs:
       - api-client
       - commit-api-client
-    if: ${{ always() && inputs.typecheck && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') }}
+    if: ${{ !cancelled() && inputs.typecheck && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -346,7 +346,7 @@ jobs:
       - lint
       - commit-lint
       - check-types
-    if: ${{ always() && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.commit-lint.result == 'success' || needs.commit-lint.result == 'skipped') && (needs.check-types.result == 'success' || needs.check-types.result == 'skipped') }}
+    if: ${{ !cancelled() && !startsWith(github.ref, 'refs/tags/') && (needs.api-client.result == 'success' || needs.api-client.result == 'skipped') && (needs.commit-api-client.result == 'success' || needs.commit-api-client.result == 'skipped') && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.commit-lint.result == 'success' || needs.commit-lint.result == 'skipped') && (needs.check-types.result == 'success' || needs.check-types.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.capture.outputs.has_changes }}
@@ -453,7 +453,7 @@ jobs:
     needs:
       - build
       - commit-build
-    if: ${{ always() && inputs.test && !startsWith(github.ref, 'refs/tags/') && needs.build.result == 'success' && (needs.commit-build.result == 'success' || needs.commit-build.result == 'skipped') }}
+    if: ${{ !cancelled() && inputs.test && !startsWith(github.ref, 'refs/tags/') && needs.build.result == 'success' && (needs.commit-build.result == 'success' || needs.commit-build.result == 'skipped') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -98,10 +98,10 @@ env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  # Read-only: regenerates the API client (repo-provided code) from the committed
-  # OpenAPI spec and captures the result as a patch artifact. Runs before
-  # lint/typecheck/build so those operate on the freshly generated client. The
-  # write token is NOT present here.
+  # Read-only: regenerates the API client and captures it as a patch. No write
+  # token here. On fork PRs commit-api-client is skipped, so the patch is never
+  # committed and lint/typecheck/build/test validate the committed (possibly
+  # stale) client; the next non-fork run regenerates and commits it.
   api-client:
     if: ${{ inputs.api-client && !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -435,6 +435,11 @@ jobs:
 
   # Read-only: runs the repo's test script after the build (and after any build
   # output has been committed). No write token here.
+  # NOTE: this job checks out the branch fresh and does NOT re-run the build. If
+  # the test script consumes build artifacts, enable commit-build-output so the
+  # output is committed first; otherwise (or on fork PRs, where commit-build is
+  # skipped) the checkout has no fresh build. studio-ui's jest runs against
+  # source, so it does not depend on the build output.
   test:
     needs:
       - build


### PR DESCRIPTION
## What

Extends the two reusable frontend workflows so bundles can opt into extra CI steps and per-branch canary publishing, without changing behaviour for current consumers.

### reusable-studio-frontend-build.yaml
- New optional **`api-client`** job — regenerates the API client and commits it, ordered before lint/typecheck/build.
- New optional **`test`** job — runs after the build.
- Both are **default `false`**, so existing callers (dashboards, etc.) are unaffected. Both follow the existing hardened pattern: a read-only job runs repo code and captures a patch, a separate write-gated, non-fork job applies + commits it.

### reusable-frontend-publish-unified.yaml
- Passes `api-client` / `test` through to the build.
- New **`canary-tag`** input (default `canary`) so callers can publish per-branch canary dist-tags (e.g. `canary-2026.2`).
- New **`npm-cli-version`** input (default `latest`) for the publish step.
- Publish auth is unchanged (OIDC trusted publishing via `--provenance`, no token).

## Why
studio-ui-bundle needs api-client generation + tests in CI, which the shared workflow didn't support; and per Markus, canaries should publish from every live version branch under a per-branch tag. Making these optional lets other bundles adopt them later by flipping a toggle.

## Backward compatibility
All new inputs default to today's behaviour. No change for existing callers until they opt in.

## Notes / to verify
- The new job-dependency gating (`always() && success-or-skipped`) should be confirmed with a real run.
- Draft until the studio-ui-bundle side (which consumes this) is reviewed together.