### PR TITLE
Fix commit jobs skipped on non-PR events in studio frontend build

### DIFF
--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -161,7 +161,7 @@ jobs:
   # patch and commits it. Gated to non-fork contexts.
   commit-api-client:
     needs: api-client
-    if: ${{ inputs.api-client && needs.api-client.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.api-client && needs.api-client.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -264,7 +264,7 @@ jobs:
   # produced above and commits it. Gated to non-fork contexts.
   commit-lint:
     needs: lint
-    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -410,7 +410,7 @@ jobs:
   # patch and commits it. Gated to non-fork contexts.
   commit-build:
     needs: build
-    if: ${{ inputs.commit-build-output && needs.build.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-build-output && needs.build.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -161,7 +161,7 @@ jobs:
   # patch and commits it. Gated to non-fork contexts.
   commit-api-client:
     needs: api-client
-    if: ${{ inputs.api-client && needs.api-client.outputs.has_changes == 'true' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.api-client && needs.api-client.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -264,7 +264,7 @@ jobs:
   # produced above and commits it. Gated to non-fork contexts.
   commit-lint:
     needs: lint
-    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -410,7 +410,7 @@ jobs:
   # patch and commits it. Gated to non-fork contexts.
   commit-build:
     needs: build
-    if: ${{ inputs.commit-build-output && needs.build.outputs.has_changes == 'true' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-build-output && needs.build.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Fixes pimcore/workflows-collection-public#126

## Problem

`commit-api-client`, `commit-lint` and `commit-build` in `reusable-studio-frontend-build.yaml` guard their non-fork check like this:

```yaml
(github.event.pull_request.head.repo.full_name == ''
 || github.event.pull_request.head.repo.full_name == github.repository)
```

The `== ''` branch was meant to let non-PR events (`push`, `workflow_dispatch`, `schedule`) through, where there is no PR head repo. In practice it does not — in run [pimcore/headless-documents#29809623112](https://github.com/pimcore/headless-documents/actions/runs/29809623112) (`workflow_dispatch`), the `build` job produced a real **327 KB `build-output-patch`** (uploaded artifact ⇒ `has_changes == 'true'`), yet **`commit-build` was skipped** and the built assets were never committed. Comparing a null-dereferenced property chain to `''` is not a reliable way to detect non-PR events (GitHub's expression docs don't specify that coercion), so the guard failed closed.

This mechanism is new and had **never** successfully committed on any consuming repo.

## Fix

Replace the ambiguous null comparison with an explicit event check on all three commit jobs:

```yaml
((github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
 || github.event.pull_request.head.repo.full_name == github.repository)
```

Correct by construction for every event type — and it preserves the documented fork-protection invariant (fork PRs must never get the write-capable commit jobs, incl. under `pull_request_target`):

| Event | `full_name` | Gate | Result |
|-------|-------------|------|--------|
| `push` / `workflow_dispatch` / `schedule` | n/a | first clause **true** | commit runs |
| same-repo `pull_request` / `pull_request_target` | `= github.repository` | string compare **true** | commit runs |
| **fork** `pull_request` | fork repo | both clauses **false** | commit blocked |
| **fork** `pull_request_target` | fork repo | both clauses **false** | commit blocked |

`github.event_name` is always present (no null-coercion ambiguity), and for non-PR events the guard never touches `github.event.pull_request.*`. The string comparison `full_name == github.repository` is string-vs-string, which is not subject to numeric coercion.

> Note: an earlier revision of this PR checked only `!= 'pull_request'`, which would have let a fork's `pull_request_target` run reach the write-capable commit job — corrected here to exclude `pull_request_target` as well.

## After merge

Consuming repos that ran this workflow and rely on the auto-commit (e.g. `pimcore/headless-documents` `2026.x`) are missing their committed build output and should re-run the workflow once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)