### PR TITLE
Fix commit jobs skipped on non-PR events in packaged studio frontend build

### DIFF
--- a/.github/workflows/reusable-studio-frontend-build-packaged.yaml
+++ b/.github/workflows/reusable-studio-frontend-build-packaged.yaml
@@ -161,7 +161,7 @@ jobs:
   # produced above and commits it. Gated to non-fork contexts.
   commit-lint:
     needs: lint
-    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -278,7 +278,7 @@ jobs:
   # archive and commits it. Gated to non-fork contexts.
   commit-build:
     needs: build
-    if: ${{ inputs.commit-build-output && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-build-output && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/reusable-studio-frontend-build-packaged.yaml
+++ b/.github/workflows/reusable-studio-frontend-build-packaged.yaml
@@ -161,7 +161,7 @@ jobs:
   # produced above and commits it. Gated to non-fork contexts.
   commit-lint:
     needs: lint
-    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -278,7 +278,7 @@ jobs:
   # archive and commits it. Gated to non-fork contexts.
   commit-build:
     needs: build
-    if: ${{ inputs.commit-build-output && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ inputs.commit-build-output && ((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Sibling fix to #127 (same bug, different reusable workflow).

## Problem

`reusable-studio-frontend-build-packaged.yaml` guards its `commit-lint` and `commit-build` jobs with the same broken fork check as the non-packaged workflow:

```yaml
(github.event.pull_request.head.repo.full_name == ''
 || github.event.pull_request.head.repo.full_name == github.repository)
```

The `== ''` branch is meant to let non-PR events (`push`, `workflow_dispatch`, `schedule`) through, but it does not hold at runtime for those events (comparing a null-dereferenced property chain to `''` is unreliable), so the commit jobs are skipped and nothing is committed. See #126 / #127 for the full analysis and the observed failure on the non-packaged variant.

## Fix

Replace it with an explicit event check on both commit jobs:

```yaml
((github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
 || github.event.pull_request.head.repo.full_name == github.repository)
```

| Event | Result |
|-------|--------|
| `push` / `workflow_dispatch` / `schedule` | ✅ commit runs |
| same-repo `pull_request` / `pull_request_target` | ✅ commit runs |
| **fork** `pull_request` | 🚫 blocked |
| **fork** `pull_request_target` | 🚫 blocked (fork-protection invariant preserved) |

`github.event_name` is always present (no null-coercion ambiguity), and for non-PR events the guard never touches `github.event.pull_request.*`.

Identical change to #127, applied to the packaged variant's two commit jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
