### PR TITLE
Fix commit-* jobs cascade-skipped by skipped upstream jobs (real cause of build output never committed)

### DIFF
--- a/.github/workflows/reusable-studio-frontend-build-packaged.yaml
+++ b/.github/workflows/reusable-studio-frontend-build-packaged.yaml
@@ -161,7 +161,9 @@ jobs:
   # produced above and commits it. Gated to non-fork contexts.
   commit-lint:
     needs: lint
-    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # `!cancelled()` is REQUIRED: skipped upstream jobs otherwise cascade their
+    # `skipped` onto this job even though `lint` succeeded. Do NOT remove it.
+    if: ${{ !cancelled() && needs.lint.result == 'success' && inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -278,7 +280,10 @@ jobs:
   # archive and commits it. Gated to non-fork contexts.
   commit-build:
     needs: build
-    if: ${{ inputs.commit-build-output && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # `!cancelled()` is REQUIRED: `build`'s skipped upstreams otherwise cascade
+    # their `skipped` onto this job even though `build` succeeded — which
+    # silently prevents the build archive from being committed. Do NOT remove it.
+    if: ${{ !cancelled() && needs.build.result == 'success' && inputs.commit-build-output && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -161,7 +161,11 @@ jobs:
   # patch and commits it. Gated to non-fork contexts.
   commit-api-client:
     needs: api-client
-    if: ${{ inputs.api-client && needs.api-client.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # `!cancelled()` is REQUIRED: this job's upstreams (lint/commit-lint,
+    # check-types, and — when enabled — the other commit-* jobs) are frequently
+    # `skipped`, and without a status-check function that skip cascades onto this
+    # job even though `api-client` itself succeeded. Do NOT remove it.
+    if: ${{ !cancelled() && needs.api-client.result == 'success' && inputs.api-client && needs.api-client.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -264,7 +268,10 @@ jobs:
   # produced above and commits it. Gated to non-fork contexts.
   commit-lint:
     needs: lint
-    if: ${{ inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # `!cancelled()` is REQUIRED: skipped upstream jobs (e.g. commit-api-client,
+    # or api-client when disabled) otherwise cascade their `skipped` onto this
+    # job even though `lint` succeeded. Do NOT remove it.
+    if: ${{ !cancelled() && needs.lint.result == 'success' && inputs.commit-lint-output && needs.lint.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -410,7 +417,12 @@ jobs:
   # patch and commits it. Gated to non-fork contexts.
   commit-build:
     needs: build
-    if: ${{ inputs.commit-build-output && needs.build.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # `!cancelled()` is REQUIRED: `build`'s upstreams (commit-lint, and the
+    # api-client jobs) are `skipped` in the common case, and without a
+    # status-check function that skip cascades onto this job even though `build`
+    # itself succeeded — which silently prevents built assets from being
+    # committed. Do NOT remove it.
+    if: ${{ !cancelled() && needs.build.result == 'success' && inputs.commit-build-output && needs.build.outputs.has_changes == 'true' && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Fixes pimcore/workflows-collection-public#126 (the actual root cause).

## TL;DR
The auto-commit of built Studio assets has **never worked** since the split-job refactor (#120). The cause is **not** the fork guard (that was a real but *secondary* issue, fixed in #127). The real cause: `commit-api-client`, `commit-lint` and `commit-build` are **cascade-skipped** by their skipped upstream jobs.

## Root cause
`build` (and `lint`, `api-client`) list other jobs in `needs` that are routinely **skipped**:
- `commit-lint` is skipped whenever lint produces no fixes,
- `api-client` / `commit-api-client` are skipped whenever the API client is disabled (the default).

`build` runs anyway via `if: !cancelled() && …`. But the downstream `commit-*` jobs had **no status-check function** in their `if`, so GitHub cascades the upstream `skipped` onto them — even though the producing job **succeeded** and `has_changes == 'true'`. So `commit-build` skipped every time, and built assets were never committed.

## Proof (empirical)
Minimal repro on a scratch branch (deleted), mirroring the exact structure — a `build`-like job with a **skipped** `needs` + `if: !cancelled()` that sets `has_changes=true`:

| downstream job gate | result |
|---|---|
| `needs.build.outputs.has_changes == 'true'` (current) | **skipped** ← the bug |
| `needs.build.result == 'success'` (no status fn) | skipped |
| `!cancelled() && needs.build.result == 'success' && …== 'true'` (**fix**) | **✅ fired** |
| identical to current, but build had **no** skipped `needs` (control) | fired |

An `observe` job (`if: !cancelled()`) confirmed the output propagated correctly the whole time: `needs.build.outputs.has_changes=[true]`, `needs.build.result=[success]`. So it was never an output-propagation problem — purely the skip-cascade.

## Fix
Prepend `!cancelled() && needs.<producer>.result == 'success'` to each `commit-*` gate:

```yaml
if: ${{ !cancelled() && needs.build.result == 'success'
    && inputs.commit-build-output && needs.build.outputs.has_changes == 'true'
    && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository) }}
```

- `!cancelled()` stops the cascade;
- `needs.<producer>.result == 'success'` keeps the correct "only commit when the build/lint/api-client actually succeeded" semantics (so we don't commit off a failed build);
- `has_changes` and fork-guard conditions are unchanged.

An inline comment marks `!cancelled()` as load-bearing so it isn't "simplified" away later.

## Relationship to other PRs
- #127 (merged): fork-guard hardening — necessary, but did **not** fix the skips.
- **This PR now covers BOTH** `reusable-studio-frontend-build.yaml` and `reusable-studio-frontend-build-packaged.yaml` (identical commit-* jobs), and aligns the packaged fork guard to #127's merged form. **Supersedes #128.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)