### PR TITLE
Use git-auto-commit-action@v7 before_push_hook instead of the invalid pull input

### DIFF
--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -193,7 +193,10 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           # Rebase onto the remote tip before pushing so a concurrent push to the
           # same branch doesn't fail this with a non-fast-forward rejection.
-          pull: "--rebase --autostash"
+          # NB: `pull:` is not a valid input on git-auto-commit-action@v7 (it was
+          # silently ignored, emitting an "Unexpected input(s) 'pull'" warning);
+          # v7's `before_push_hook` is the supported way to do this.
+          before_push_hook: git pull --rebase --autostash origin ${{ env.BRANCH_NAME }}
           commit_message: Apply latest automatic api client updates
 
   # Read-only: executes repo-provided code (npm hooks + lint script). Captures
@@ -299,7 +302,10 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           # Rebase onto the remote tip before pushing so a concurrent push to the
           # same branch doesn't fail this with a non-fast-forward rejection.
-          pull: "--rebase --autostash"
+          # NB: `pull:` is not a valid input on git-auto-commit-action@v7 (it was
+          # silently ignored, emitting an "Unexpected input(s) 'pull'" warning);
+          # v7's `before_push_hook` is the supported way to do this.
+          before_push_hook: git pull --rebase --autostash origin ${{ env.BRANCH_NAME }}
           commit_message: Apply eslint-fixer changes
 
   check-types:
@@ -451,7 +457,10 @@ jobs:
           file_pattern: ${{ inputs.build-output-path }}
           # Rebase onto the remote tip before pushing so a concurrent push to the
           # same branch doesn't fail this with a non-fast-forward rejection.
-          pull: "--rebase --autostash"
+          # NB: `pull:` is not a valid input on git-auto-commit-action@v7 (it was
+          # silently ignored, emitting an "Unexpected input(s) 'pull'" warning);
+          # v7's `before_push_hook` is the supported way to do this.
+          before_push_hook: git pull --rebase --autostash origin ${{ env.BRANCH_NAME }}
           commit_message: Automatic frontend build
 
   # Read-only: runs the repo's test script after the build (and after any build


### PR DESCRIPTION
## Problem
The three `commit-*` steps in `reusable-studio-frontend-build.yaml` passed:

```yaml
uses: stefanzweifel/git-auto-commit-action@v7
with:
  pull: "--rebase --autostash"
```

`pull` is **not a valid input on git-auto-commit-action@v7** — it was silently ignored and produced an `Unexpected input(s) 'pull'` warning on every commit job. So the intended behaviour (rebase onto the remote tip before pushing, to avoid a non-fast-forward rejection when commits race to the same branch) **never actually ran**.

## Fix
Replace `pull:` with v7's supported [`before_push_hook`](https://github.com/stefanzweifel/git-auto-commit-action#example-workflow), which runs a command right before the push:

```yaml
before_push_hook: git pull --rebase --autostash origin ${{ env.BRANCH_NAME }}
```

Applied to all three commit steps (`commit-api-client`, `commit-lint`, `commit-build`). The commit jobs check out with credentials, so the pull authenticates fine.

## Validated
Ran on a `headless-documents` scratch branch pointed at this branch (`workflow_dispatch`), then deleted the branch:
- `commit-build` → **success** (committed as normal)
- **`Unexpected input(s) 'pull'` warning: gone** (0 occurrences)
- `before_push_hook` executed: log shows `git pull --rebase --autostash origin <branch>` → `Current branch … is up to date` — the rebase-before-push is now actually active.

Independent of the skip-cascade fix (#129); purely removes the invalid input and restores the intended concurrent-push protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)