### PR TITLE
Add opt-in fork-PR checkout for gated codeception runs

### DIFF
--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -164,6 +164,9 @@ jobs:
           # caller gates this job behind reusable-fork-pr-security-gate and passes
           # allow_fork_pr_checkout: true only on the gate-approved path. Defaults false.
           allow-unsafe-pr-checkout: ${{ inputs.allow_fork_pr_checkout }}
+          # Fork code runs with secrets in scope; don't leave the base-repo GITHUB_TOKEN
+          # in .git/config for it to read. This job never pushes, so it needs no credentials.
+          persist-credentials: false
 
       - name: "Get target branch information"
         id: branch-info

--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       allow_fork_pr_checkout:
-        description: "Enable actions/checkout allow-unsafe-pr-checkout. Set true ONLY when the caller has run the fork-PR security gate (reusable-fork-pr-security-gate) before this job."
+        description: "Enable actions/checkout allow-unsafe-pr-checkout, which checks out untrusted fork-PR head code with this job's secrets in scope. Set true ONLY from a caller job that both (1) declares needs on reusable-fork-pr-security-gate and (2) runs only when the gate verdict is not a rejection. A bare true without that gating exposes the job secrets to fork code."
         required: false
         type: boolean
         default: false

--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -3,6 +3,11 @@ name: "Codeception tests"
 on:
   workflow_call:
     inputs:
+      allow_fork_pr_checkout:
+        description: "Enable actions/checkout allow-unsafe-pr-checkout. Set true ONLY when the caller has run the fork-PR security gate (reusable-fork-pr-security-gate) before this job."
+        required: false
+        type: boolean
+        default: false
       APP_ENV:
         required: true
         type: string
@@ -155,6 +160,10 @@ jobs:
         uses: "actions/checkout@v5"
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Re-enables the intentionally-blocked fork-PR checkout. Safe ONLY because the
+          # caller gates this job behind reusable-fork-pr-security-gate and passes
+          # allow_fork_pr_checkout: true only on the gate-approved path. Defaults false.
+          allow-unsafe-pr-checkout: ${{ inputs.allow_fork_pr_checkout }}
 
       - name: "Get target branch information"
         id: branch-info


### PR DESCRIPTION
## Draft — needs security review before merge

`actions/checkout` now refuses fork-PR checkout under `pull_request_target` (pwn-request guardrail), so this reusable's `head.sha` checkout fails for **every fork PR** — e.g. generic-data-index-bundle run 29804774980.

**Change:** add an `allow_fork_pr_checkout` input (default `false`), passed to `actions/checkout` as `allow-unsafe-pr-checkout`.

**Safe by default:** existing callers are unchanged (defaults `false`, still fail-closed). A caller may set it `true` **only** after running `reusable-fork-pr-security-gate` and gating the job on its verdict — see the companion caller PR pimcore/generic-data-index-bundle#472.

**Merge order:** first merge the gate (`workflow_gate` → `main`), then this, then pilot on a real fork PR.

Refs: pimcore/product-management#1303 · pimcore/product-management#1311 (§5)
