### PR TITLE
CI guardrail: poll for a definitive result (don't rely on check_suite)

### DIFF
--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -8,7 +8,8 @@ name: "PR Guardrails pipeline"
 # Pipeline:
 #   membership  (all events) ─► outputs.bypass
 #   issue-link  (PR events, only when not bypassed)   needs: membership
-#   ci          (PR + check_suite events, only when not bypassed)   needs: membership
+#   ci          (PR events, only when not bypassed; polls CI to a definitive result
+#               rather than relying on check_suite, which Actions does not re-deliver)   needs: membership
 #
 # Each stage that fails converts the PR to draft and comments. Stages run
 # independently and report individually (a failure does not cancel later stages).

--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -8,8 +8,9 @@ name: "PR Guardrails pipeline"
 # Pipeline:
 #   membership  (all events) ─► outputs.bypass
 #   issue-link  (PR events, only when not bypassed)   needs: membership
-#   ci          (PR events, only when not bypassed; polls CI to a definitive result
-#               rather than relying on check_suite, which Actions does not re-deliver)   needs: membership
+#   ci          (all events, only when not bypassed; still invoked on check_suite as
+#               well as PR events, but polls CI to a definitive result rather than
+#               relying on check_suite re-delivery, which Actions does not do)   needs: membership
 #
 # Each stage that fails converts the PR to draft and comments. Stages run
 # independently and report individually (a failure does not cancel later stages).

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -5,7 +5,9 @@ name: "Reusable Guardrail: CI & merge readiness"
 # checks or the mergeability computation are still in progress the guardrail stays
 # neutral (it does not draft). On a definitive failure the PR is converted to
 # draft with an explanatory comment. The guardrail ignores its own "Guardrail:"
-# checks to avoid self-deadlock. Runs on PR events and on check_suite completion.
+# checks to avoid self-deadlock. Runs on PR events and POLLS the head commit until
+# CI is decisive — it does NOT rely on check_suite completion, which GitHub does not
+# re-deliver for check suites created by GitHub Actions (Pimcore CI is Actions-based).
 #
 # Called by parent-pr-guardrails.yml in the caller's event context.
 
@@ -114,45 +116,67 @@ jobs:
                 pendingReasons.push('mergeability is still being computed by GitHub');
               }
 
-              // 2) CI check runs. octokit's paginate already flattens this
-              // endpoint's { total_count, check_runs } response into a plain array
-              // of check runs (no map function — with one, response.data is the
-              // already-normalized array, so .check_runs would be undefined).
-              // A SHA accumulates a check run per (re-)run, so keep only the LATEST
-              // run per check name (highest id) — otherwise a stale failure that was
-              // later re-run green would still count. Then drop our own guardrail checks.
-              const allChecks = await github.paginate(github.rest.checks.listForRef, {
-                ...context.repo, ref: headSha, per_page: 100,
-              });
-              const latestByName = new Map();
-              for (const c of allChecks) {
-                const prev = latestByName.get(c.name);
-                if (!prev || c.id > prev.id) latestByName.set(c.name, c);
-              }
-              const others = [...latestByName.values()].filter((c) => !isGuardrailCheck(c.name));
-              const pendingChecks = others.filter((c) => c.status !== 'completed');
-              const failedChecks = others.filter(
-                (c) => c.status === 'completed' && !['success', 'neutral', 'skipped'].includes(c.conclusion),
-              );
+              // 2) & 3) CI check runs + legacy commit statuses on the head commit.
+              // IMPORTANT: we must not rely on a later `check_suite: completed` event
+              // to re-evaluate CI — GitHub does NOT re-deliver check_suite for suites
+              // created by GitHub Actions (recursion prevention), and Pimcore CI is
+              // Actions-based. So we POLL the head commit here until every check/status
+              // has completed (or a timeout), then decide definitively. A merge conflict
+              // (found above) is already terminal, so skip the CI wait in that case.
+              if (failures.length === 0) {
+                const POLL_INTERVAL_MS = 30000;
+                const POLL_DEADLINE = Date.now() + 45 * 60 * 1000; // 45 min cap, then stay neutral
+                const isFinalConclusion = (c) => ['success', 'neutral', 'skipped'].includes(c);
+                // eslint-disable-next-line no-constant-condition
+                while (true) {
+                  // Latest run per check name (highest id); drop our own guardrail checks.
+                  const allChecks = await github.paginate(github.rest.checks.listForRef, {
+                    ...context.repo, ref: headSha, per_page: 100,
+                  });
+                  const latestByName = new Map();
+                  for (const c of allChecks) {
+                    const prev = latestByName.get(c.name);
+                    if (!prev || c.id > prev.id) latestByName.set(c.name, c);
+                  }
+                  const others = [...latestByName.values()].filter((c) => !isGuardrailCheck(c.name));
+                  const pendingChecks = others.filter((c) => c.status !== 'completed');
+                  const failedChecks = others.filter(
+                    (c) => c.status === 'completed' && !isFinalConclusion(c.conclusion),
+                  );
 
-              // 3) Legacy commit statuses. Dedupe by context (keep the latest by id)
-              // so an earlier failure does not linger after a later success.
-              const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
-                ...context.repo, ref: headSha,
-              });
-              const latestStatusByContext = new Map();
-              for (const s of combined.statuses) {
-                const prev = latestStatusByContext.get(s.context);
-                if (!prev || s.id > prev.id) latestStatusByContext.set(s.context, s);
-              }
-              const statuses = [...latestStatusByContext.values()];
-              const failedStatuses = statuses.filter((s) => s.state === 'failure' || s.state === 'error');
-              const pendingStatuses = statuses.filter((s) => s.state === 'pending');
+                  // Legacy commit statuses, deduped by context (latest by id).
+                  const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+                    ...context.repo, ref: headSha,
+                  });
+                  const latestStatusByContext = new Map();
+                  for (const s of combined.statuses) {
+                    const prev = latestStatusByContext.get(s.context);
+                    if (!prev || s.id > prev.id) latestStatusByContext.set(s.context, s);
+                  }
+                  const statuses = [...latestStatusByContext.values()];
+                  const failedStatuses = statuses.filter((s) => s.state === 'failure' || s.state === 'error');
+                  const pendingStatuses = statuses.filter((s) => s.state === 'pending');
 
-              failedChecks.forEach((c) => failures.push(`CI check not successful: \`${c.name}\` (${c.conclusion}).`));
-              failedStatuses.forEach((s) => failures.push(`CI status not successful: \`${s.context}\` (${s.state}).`));
-              pendingChecks.forEach((c) => pendingReasons.push(`check \`${c.name}\` still running`));
-              pendingStatuses.forEach((s) => pendingReasons.push(`status \`${s.context}\` still pending`));
+                  // A definitive failure ends the wait immediately; otherwise wait out
+                  // still-running checks so we never pass a PR whose CI later fails.
+                  if (failedChecks.length > 0 || failedStatuses.length > 0) {
+                    failedChecks.forEach((c) => failures.push(`CI check not successful: \`${c.name}\` (${c.conclusion}).`));
+                    failedStatuses.forEach((s) => failures.push(`CI status not successful: \`${s.context}\` (${s.state}).`));
+                    break;
+                  }
+                  if (pendingChecks.length === 0 && pendingStatuses.length === 0) {
+                    break; // everything completed successfully
+                  }
+                  if (Date.now() >= POLL_DEADLINE) {
+                    pendingChecks.forEach((c) => pendingReasons.push(`check \`${c.name}\` still running`));
+                    pendingStatuses.forEach((s) => pendingReasons.push(`status \`${s.context}\` still pending`));
+                    core.warning('CI did not reach a definitive result within the poll window; staying neutral.');
+                    break;
+                  }
+                  core.info(`Waiting for CI to finish (${pendingChecks.length} checks, ${pendingStatuses.length} statuses still pending)…`);
+                  await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+                }
+              }
 
               if (failures.length > 0) {
                 if (!pr.draft) {

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -133,15 +133,43 @@ jobs:
                 // failure — the exact bug this change removes. So we only accept an
                 // all-clear once we've actually observed external CI; until then we
                 // keep polling, and if none ever appears we stay neutral at the cap.
-                // (Residual: a check registering after an earlier one completed within
-                // a poll gap is mitigated by the 30s interval and the 45-min cap.)
+                // A pass additionally requires several consecutive clean ticks, so a
+                // check that registers just after the visible set completes (queued
+                // needs: chain, workflow_run follow-up) is still caught before we
+                // declare success instead of slipping through after an early break.
                 let observedAnyCI = false;
+                const CLEAN_TICKS_REQUIRED = 3;
+                let cleanTicks = 0;
+                // A transient API error (5xx, secondary rate limit) must not fail the
+                // whole job over ~90 poll iterations: treat it as "still pending" and
+                // retry, giving up neutral after too many consecutive failures.
+                const MAX_CONSECUTIVE_API_ERRORS = 5;
+                let consecutiveApiErrors = 0;
                 // eslint-disable-next-line no-constant-condition
                 while (true) {
+                  let allChecks, combined;
+                  try {
+                    allChecks = await github.paginate(github.rest.checks.listForRef, {
+                      ...context.repo, ref: headSha, per_page: 100,
+                    });
+                    ({ data: combined } = await github.rest.repos.getCombinedStatusForRef({
+                      ...context.repo, ref: headSha,
+                    }));
+                    consecutiveApiErrors = 0;
+                  } catch (e) {
+                    consecutiveApiErrors += 1;
+                    cleanTicks = 0; // only verified-clean ticks count toward a pass
+                    core.warning(`Transient API error while polling CI (${consecutiveApiErrors}/${MAX_CONSECUTIVE_API_ERRORS}): ${e.message}`);
+                    if (consecutiveApiErrors >= MAX_CONSECUTIVE_API_ERRORS || Date.now() >= POLL_DEADLINE) {
+                      pendingReasons.push('CI state could not be read (repeated API errors during the poll window)');
+                      core.warning('Giving up polling after repeated API errors; staying neutral.');
+                      break;
+                    }
+                    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+                    continue;
+                  }
+
                   // Latest run per check name (highest id); drop our own guardrail checks.
-                  const allChecks = await github.paginate(github.rest.checks.listForRef, {
-                    ...context.repo, ref: headSha, per_page: 100,
-                  });
                   const latestByName = new Map();
                   for (const c of allChecks) {
                     const prev = latestByName.get(c.name);
@@ -154,9 +182,6 @@ jobs:
                   );
 
                   // Legacy commit statuses, deduped by context (latest by id).
-                  const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
-                    ...context.repo, ref: headSha,
-                  });
                   const latestStatusByContext = new Map();
                   for (const s of combined.statuses) {
                     const prev = latestStatusByContext.get(s.context);
@@ -176,12 +201,21 @@ jobs:
                     break;
                   }
                   if (observedAnyCI && pendingChecks.length === 0 && pendingStatuses.length === 0) {
-                    break; // observed CI and everything completed successfully
+                    cleanTicks += 1;
+                    if (cleanTicks >= CLEAN_TICKS_REQUIRED) {
+                      break; // observed CI, everything completed clean, and it stayed clean
+                    }
+                    core.info(`All observed CI complete & clean; settling (${cleanTicks}/${CLEAN_TICKS_REQUIRED})…`);
+                  } else {
+                    cleanTicks = 0;
                   }
                   if (Date.now() >= POLL_DEADLINE) {
                     if (!observedAnyCI) {
                       pendingReasons.push('no external CI checks were observed for this commit within the poll window');
                       core.warning('No external CI observed within the poll window; staying neutral.');
+                    } else if (cleanTicks > 0) {
+                      // Clean when the cap hit, just not fully settled: accept the pass.
+                      core.info('Poll window ended while confirming a clean result; accepting the pass.');
                     } else {
                       pendingChecks.forEach((c) => pendingReasons.push(`check \`${c.name}\` still running`));
                       pendingStatuses.forEach((s) => pendingReasons.push(`status \`${s.context}\` still pending`));
@@ -189,9 +223,11 @@ jobs:
                     }
                     break;
                   }
-                  core.info(observedAnyCI
-                    ? `Waiting for CI to finish (${pendingChecks.length} checks, ${pendingStatuses.length} statuses still pending)…`
-                    : 'No external CI checks registered yet; waiting for them to appear…');
+                  if (cleanTicks === 0) {
+                    core.info(observedAnyCI
+                      ? `Waiting for CI to finish (${pendingChecks.length} checks, ${pendingStatuses.length} statuses still pending)…`
+                      : 'No external CI checks registered yet; waiting for them to appear…');
+                  }
                   await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
                 }
               }

--- a/.github/workflows/reusable-guardrail-ci.yml
+++ b/.github/workflows/reusable-guardrail-ci.yml
@@ -127,6 +127,15 @@ jobs:
                 const POLL_INTERVAL_MS = 30000;
                 const POLL_DEADLINE = Date.now() + 45 * 60 * 1000; // 45 min cap, then stay neutral
                 const isFinalConclusion = (c) => ['success', 'neutral', 'skipped'].includes(c);
+                // On an incoming PR event we can reach the API before the repo's CI
+                // workflows have registered any check runs. If we treated "nothing
+                // visible" as success we'd pass before CI exists and miss a later
+                // failure — the exact bug this change removes. So we only accept an
+                // all-clear once we've actually observed external CI; until then we
+                // keep polling, and if none ever appears we stay neutral at the cap.
+                // (Residual: a check registering after an earlier one completed within
+                // a poll gap is mitigated by the 30s interval and the 45-min cap.)
+                let observedAnyCI = false;
                 // eslint-disable-next-line no-constant-condition
                 while (true) {
                   // Latest run per check name (highest id); drop our own guardrail checks.
@@ -157,6 +166,8 @@ jobs:
                   const failedStatuses = statuses.filter((s) => s.state === 'failure' || s.state === 'error');
                   const pendingStatuses = statuses.filter((s) => s.state === 'pending');
 
+                  if (others.length > 0 || statuses.length > 0) observedAnyCI = true;
+
                   // A definitive failure ends the wait immediately; otherwise wait out
                   // still-running checks so we never pass a PR whose CI later fails.
                   if (failedChecks.length > 0 || failedStatuses.length > 0) {
@@ -164,16 +175,23 @@ jobs:
                     failedStatuses.forEach((s) => failures.push(`CI status not successful: \`${s.context}\` (${s.state}).`));
                     break;
                   }
-                  if (pendingChecks.length === 0 && pendingStatuses.length === 0) {
-                    break; // everything completed successfully
+                  if (observedAnyCI && pendingChecks.length === 0 && pendingStatuses.length === 0) {
+                    break; // observed CI and everything completed successfully
                   }
                   if (Date.now() >= POLL_DEADLINE) {
-                    pendingChecks.forEach((c) => pendingReasons.push(`check \`${c.name}\` still running`));
-                    pendingStatuses.forEach((s) => pendingReasons.push(`status \`${s.context}\` still pending`));
-                    core.warning('CI did not reach a definitive result within the poll window; staying neutral.');
+                    if (!observedAnyCI) {
+                      pendingReasons.push('no external CI checks were observed for this commit within the poll window');
+                      core.warning('No external CI observed within the poll window; staying neutral.');
+                    } else {
+                      pendingChecks.forEach((c) => pendingReasons.push(`check \`${c.name}\` still running`));
+                      pendingStatuses.forEach((s) => pendingReasons.push(`status \`${s.context}\` still pending`));
+                      core.warning('CI did not reach a definitive result within the poll window; staying neutral.');
+                    }
                     break;
                   }
-                  core.info(`Waiting for CI to finish (${pendingChecks.length} checks, ${pendingStatuses.length} statuses still pending)…`);
+                  core.info(observedAnyCI
+                    ? `Waiting for CI to finish (${pendingChecks.length} checks, ${pendingStatuses.length} statuses still pending)…`
+                    : 'No external CI checks registered yet; waiting for them to appear…');
                   await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
                 }
               }

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -3,6 +3,7 @@ name: "Reusable Guardrail: Dev-Team membership"
 # Fast-path / bypass guardrail. Emits `bypass=true` (so the orchestrator skips
 # the issue-link and CI guardrails) when ANY of:
 #   - the PR author is a Dev-Team member, or
+#   - the PR author is the guard service account (pimcore-deployments), or
 #   - the PR carries the override label, or
 #   - a Dev-Team member pressed "Ready for review" on the PR (manual override) —
 #     in which case the override label is added so later runs keep bypassing.
@@ -118,10 +119,16 @@ jobs:
             const bypassedPrs = [];
             for (const pr of prs) {
               // PRs opened before the start date are exempt (checked before any
-              // API call). Then override label, then Dev-Team membership.
+              // API call). Then guard service account author (deterministic, no
+              // API call — team membership of a bot account is not reliable),
+              // then override label, then Dev-Team membership.
               const ageExempt = lib.isExemptByAge(pr);
+              const isGuardBotAuthor = pr.user.login === lib.GUARD_BOT;
               const hasLabel = (pr.labels || []).some((l) => l.name === OVERRIDE_LABEL);
-              let bypass = ageExempt || hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+              let bypass = ageExempt || isGuardBotAuthor || hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+              if (isGuardBotAuthor) {
+                core.info(`PR #${pr.number} authored by ${lib.GUARD_BOT} (guard service account) — exempt.`);
+              }
               if (ageExempt) {
                 core.info(`PR #${pr.number} created ${pr.created_at} is before start date ${lib.START_DATE} — exempt.`);
               }

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -54,7 +54,8 @@ is exempt) no comment is created, and any prior failure comment is removed.
   `2026-07-07`) are exempt — every guardrail skips them, so the policy only
   applies to PRs opened on/after that date.
 - **Bypass**: the membership stage emits `bypass=true` (orchestrator skips both
-  issue-link and CI) when the PR author is a Dev-Team member, the PR carries the
+  issue-link and CI) when the PR author is a Dev-Team member, the PR author is
+  the guard service account (`pimcore-deployments`), the PR carries the
   `guardrails:override` label, or a Dev-Team member overrode it (see below).
   Otherwise non-members must link a valid issue in `pimcore/platform-version`
   via a closing keyword (every closing-keyword reference must be valid) **and**


### PR DESCRIPTION
## Draft — central pipeline change, needs review + a real-PR test before merge

Fixes pimcore/product-management#1330 (flagged by Copilot on the guardrails rollout PRs).

**Problem:** the CI & merge-readiness guardrail evaluated CI at the incoming event, stayed *neutral* while checks were pending, and relied on the consumer's `check_suite: completed` trigger to re-evaluate once CI finished. GitHub **does not re-deliver `check_suite` for suites created by GitHub Actions** (recursion prevention), and all Pimcore CI is Actions-based — so the gate was never re-invoked and a CI failure appearing after the initial PR event was never caught (PR never drafted).

**Fix:** `reusable-guardrail-ci.yml` now **polls the head commit** until every check/status is `completed` (or a 45-min cap), then decides definitively:
- definitive failure → convert to draft + comment (as before);
- all complete & clean for 3 consecutive 30s ticks → pass (the settle window catches checks that register just after the visible set completes);
- still pending at the cap → stay neutral (as before); if the cap hits while clean but not yet fully settled, the pass is accepted;
- repeated API errors while polling (5 consecutive) → give up neutral instead of failing the job.

No dependency on `check_suite`. The consumer `pr-guardrails.yml` template stays **identical** (its now-dead `check_suite` trigger can be dropped in a later cleanup — harmless meanwhile). Merge-conflict detection is unchanged and short-circuits the CI wait.

**Trade-off vs alternatives:** polling keeps the uniform template but holds a runner for the CI duration on each PR event. `workflow_run` would be event-driven/cheaper but requires per-repo CI workflow names (breaks the identical template). Chose polling for uniformity; open to `workflow_run` if runner cost is a concern.

**Testing:** ✅ verified live on test PR #144 (see the results comment below): fail path (pending → failed → drafted + comment, ~90s), draft skip (11s, no polling), and pass path (green → 3 settle ticks → pass, marker comment cleared). Side finding: since GitHub's Dec 2025 change, `pull_request_target` runs **only from the default branch**, so the consumer trigger template must always live on each repo's default branch (it does today).

Related: platform-version#226, #1303.


---

**Review follow-ups (added after code review):**
- Poll loop hardened: per-tick API calls wrapped in try/catch (transient errors are treated as "still pending"; gives up neutral after 5 consecutive failures instead of crashing the job), and a pass now requires 3 consecutive clean 30s ticks so a check registering just after the visible set completes is still caught.
- PRs authored by `pimcore-deployments` (guard service account) now bypass the guardrails explicitly via an author check, instead of depending on the team-membership API.


