### PR TITLE
Replace v5 with v5.0.1 to unblock the fork prs

### DIFF
--- a/.github/workflows/create-bugfix-hotfix-release.yaml
+++ b/.github/workflows/create-bugfix-hotfix-release.yaml
@@ -205,7 +205,7 @@ jobs:
     if: ${{ !cancelled() && needs.ee-ce-sync-check.result != 'failure' && needs.resolve-sha.result == 'success' }}
     steps:
       - name: Checkout workflow repo (for composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
       - name: Validate no ExtJS
         uses: ./.github/actions/validate-no-extjs
         with:
@@ -238,7 +238,7 @@ jobs:
     steps:
       - name: Checkout workflow repo (for composite action)
         if: ${{ startsWith(needs.prepare.outputs.repo, 'ee-') }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
 
       - name: Check CE counterpart exists (releasing an EE bundle)
         id: ce_check
@@ -419,7 +419,7 @@ jobs:
       tag: ${{ needs.prepare.outputs.release_name }}
     steps:
       - name: Checkout workflow repo (for composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
       - name: Create release
         uses: ./.github/actions/create-release
         with:

--- a/.github/workflows/create-major-minor-release.yaml
+++ b/.github/workflows/create-major-minor-release.yaml
@@ -315,7 +315,7 @@ jobs:
         target: ${{ fromJSON(needs.resolve-shas.outputs.targets_json) }}
     steps:
       - name: Checkout workflow repo (for composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
       - name: Validate no ExtJS
         uses: ./.github/actions/validate-no-extjs
         with:
@@ -340,7 +340,7 @@ jobs:
         pair: ${{ fromJSON(needs.prepare.outputs.sync_pairs_json) }}
     steps:
       - name: Checkout workflow repo (for composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
       # sync_pairs only contains EE bundles whose CE counterpart is itself a
       # release target, so the CE base branch is guaranteed present.
       - name: Sync CE → EE
@@ -459,7 +459,7 @@ jobs:
         target: ${{ fromJSON(needs.resolve-shas.outputs.targets_ee_json) }}
     steps:
       - name: Checkout workflow repo (for composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
       - name: Create release
         uses: ./.github/actions/create-release
         with:
@@ -494,7 +494,7 @@ jobs:
         target: ${{ fromJSON(needs.resolve-shas.outputs.targets_ce_json) }}
     steps:
       - name: Checkout workflow repo (for composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
       - name: Create release
         uses: ./.github/actions/create-release
         with:

--- a/.github/workflows/reusable-codeception-public.yaml
+++ b/.github/workflows/reusable-codeception-public.yaml
@@ -124,7 +124,7 @@ jobs:
                 echo "repository: ${{ inputs.repository }}"
 
             - name: "Checkout code"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                 repository: ${{ inputs.repository }}
                 ref: ${{ inputs.BRANCH_NAME }}

--- a/.github/workflows/reusable-codeception-tests-8-2-only-public.yaml
+++ b/.github/workflows/reusable-codeception-tests-8-2-only-public.yaml
@@ -48,7 +48,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v5.0.1"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/reusable-codeception-tests-8-2-only.yaml
+++ b/.github/workflows/reusable-codeception-tests-8-2-only.yaml
@@ -53,7 +53,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v5.0.1"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/reusable-codeception-tests-centralized.yaml
+++ b/.github/workflows/reusable-codeception-tests-centralized.yaml
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v5.0.1"
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/reusable-codeception-tests-public.yaml
+++ b/.github/workflows/reusable-codeception-tests-public.yaml
@@ -55,7 +55,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v5.0.1"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/reusable-codeception-tests.yaml
+++ b/.github/workflows/reusable-codeception-tests.yaml
@@ -62,7 +62,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v5.0.1"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -39,12 +39,12 @@ jobs:
           IGNORE_LIST_KEY: ${{ inputs.ignore-list }}
         steps:
             - name: "Checkout depdendent workflow code"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                   ref: ${{ inputs.branch }}
 
             - name: "Checkout reusable workflow repository"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                   repository: "pimcore/workflows-collection-public"
                   path: ".workflows-collection-public"

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -39,12 +39,12 @@ jobs:
           IGNORE_LIST_KEY: ${{ inputs.ignore-list }}
         steps:
             - name: "Checkout depdendent workflow code"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                   ref: ${{ inputs.branch }}
 
             - name: "Checkout reusable workflow repository"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                   repository: "pimcore/workflows-collection-public"
                   path: ".workflows-collection-public"

--- a/.github/workflows/reusable-composer-test.yml
+++ b/.github/workflows/reusable-composer-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v5.0.1"
 
       - name: "Test that php version is set in composer.json"
         if: ${{ inputs.check-php-version == true }}

--- a/.github/workflows/reusable-composer-vulnerabilities.yaml
+++ b/.github/workflows/reusable-composer-vulnerabilities.yaml
@@ -33,12 +33,12 @@ jobs:
           IGNORE_LIST_KEY: ${{ inputs.ignore-list }}
         steps:
             - name: "Checkout depdendent workflow code"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                   ref: ${{ inputs.branch }}
 
             - name: "Checkout reusable workflow repository"
-              uses: "actions/checkout@v5"
+              uses: "actions/checkout@v5.0.1"
               with:
                   repository: "pimcore/workflows-collection-public"
                   path: ".workflows-collection-public"

--- a/.github/workflows/reusable-docs.yaml
+++ b/.github/workflows/reusable-docs.yaml
@@ -43,7 +43,7 @@ jobs:
     
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: >-
             ${{
@@ -54,7 +54,7 @@ jobs:
             }}
 
       - name: "Checkout Docs Generator"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           repository: "pimcore/docs-generator"
           ref: ${{ inputs.docs_generator_ref }}

--- a/.github/workflows/reusable-frontend-publish-unified.yaml
+++ b/.github/workflows/reusable-frontend-publish-unified.yaml
@@ -139,7 +139,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/reusable-osv-checks.yaml
+++ b/.github/workflows/reusable-osv-checks.yaml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: '${{ inputs.platform-version }}'
 
       - name: Checkout osv configuration
         if: ${{ inputs.composer-check-only == false }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           repository: pimcore/workflows-collection-public
           ref: main

--- a/.github/workflows/reusable-php-cs-fixer.yaml
+++ b/.github/workflows/reusable-php-cs-fixer.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: write # for stefanzweifel/git-auto-commit-action to push code in repo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.1
         with:
           ref: >-
             ${{

--- a/.github/workflows/reusable-php-style.yaml
+++ b/.github/workflows/reusable-php-style.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.1
         with:
           ref: >-
             ${{

--- a/.github/workflows/reusable-pr-clone.yaml
+++ b/.github/workflows/reusable-pr-clone.yaml
@@ -33,7 +33,7 @@ jobs:
       GIT_EMAIL: ${{ secrets.GIT_EMAIL}}
     steps:
       - name: Checkout repository CE
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
             ref: ${{ inputs.head_ref }}
             token: ${{ secrets.SYNC_TOKEN }}

--- a/.github/workflows/reusable-static-analysis-unified.yaml
+++ b/.github/workflows/reusable-static-analysis-unified.yaml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: >-
             ${{

--- a/.github/workflows/reusable-studio-frontend-build-packaged.yaml
+++ b/.github/workflows/reusable-studio-frontend-build-packaged.yaml
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -171,7 +171,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.repository }}
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -238,7 +238,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -291,7 +291,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.repository }}

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -173,7 +173,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.repository }}
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -282,7 +282,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.repository }}
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -366,7 +366,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -436,7 +436,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.repository }}
@@ -479,7 +479,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/reusable-sync-changes.yaml
+++ b/.github/workflows/reusable-sync-changes.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.1
         with:
             ref: ${{ inputs.base_ref }}
             token: ${{ secrets.SYNC_TOKEN }}


### PR DESCRIPTION
This pull request updates the version of the `actions/checkout` GitHub Action from `v5` to `v5.0.1` across all workflow files. This ensures that all workflows use the latest patch release of the action, which may include important bug fixes and improvements.

**CI/CD Workflow Maintenance:**

* Updated all instances of `actions/checkout@v5` to `actions/checkout@v5.0.1` in the following workflow files to ensure consistency and to leverage the latest fixes:
  - `.github/workflows/create-bugfix-hotfix-release.yaml` [[1]](diffhunk://#diff-4b30c70df53caa630168b38903468e9bd483dcb81c0fa98709242b6117f6d907L208-R208) [[2]](diffhunk://#diff-4b30c70df53caa630168b38903468e9bd483dcb81c0fa98709242b6117f6d907L241-R241) [[3]](diffhunk://#diff-4b30c70df53caa630168b38903468e9bd483dcb81c0fa98709242b6117f6d907L422-R422)
  - `.github/workflows/create-major-minor-release.yaml` [[1]](diffhunk://#diff-c89a062b295e96902d8415fa612f8336efabcd06ec508cc3a5dd82e416ba5a65L318-R318) [[2]](diffhunk://#diff-c89a062b295e96902d8415fa612f8336efabcd06ec508cc3a5dd82e416ba5a65L343-R343) [[3]](diffhunk://#diff-c89a062b295e96902d8415fa612f8336efabcd06ec508cc3a5dd82e416ba5a65L462-R462) [[4]](diffhunk://#diff-c89a062b295e96902d8415fa612f8336efabcd06ec508cc3a5dd82e416ba5a65L497-R497)
  - `.github/workflows/reusable-codeception-public.yaml`
  - `.github/workflows/reusable-codeception-tests-8-2-only-public.yaml`
  - `.github/workflows/reusable-codeception-tests-8-2-only.yaml`
  - `.github/workflows/reusable-codeception-tests-centralized.yaml`
  - `.github/workflows/reusable-codeception-tests-public.yaml`
  - `.github/workflows/reusable-codeception-tests.yaml`
  - `.github/workflows/reusable-composer-checks.yaml`
  - `.github/workflows/reusable-composer-recursive-checks.yaml`
  - `.github/workflows/reusable-composer-test.yml`
  - `.github/workflows/reusable-composer-vulnerabilities.yaml`
  - `.github/workflows/reusable-docs.yaml` [[1]](diffhunk://#diff-9101562180d258df805eaed2a94216b3f7d736822504419d3402aa475b481043L46-R46) [[2]](diffhunk://#diff-9101562180d258df805eaed2a94216b3f7d736822504419d3402aa475b481043L57-R57)
  - `.github/workflows/reusable-frontend-publish-unified.yaml`
  - `.github/workflows/reusable-osv-checks.yaml`
  - `.github/workflows/reusable-php-cs-fixer.yaml`
  - `.github/workflows/reusable-php-style.yaml`
  - `.github/workflows/reusable-pr-clone.yaml`
  - `.github/workflows/reusable-static-analysis-unified.yaml`
  - `.github/workflows/reusable-studio-frontend-build-packaged.yaml` [[1]](diffhunk://#diff-0466f7281f1727f661a548080f28c0fe6cf2d1f9753e0389950a98a9579e46edL109-R109) [[2]](diffhunk://#diff-0466f7281f1727f661a548080f28c0fe6cf2d1f9753e0389950a98a9579e46edL174-R174) [[3]](diffhunk://#diff-0466f7281f1727f661a548080f28c0fe6cf2d1f9753e0389950a98a9579e46edL200-R200) [[4]](diffhunk://#diff-0466f7281f1727f661a548080f28c0fe6cf2d1f9753e0389950a98a9579e46edL241-R241) [[5]](diffhunk://#diff-0466f7281f1727f661a548080f28c0fe6cf2d1f9753e0389950a98a9579e46edL294-R294)

This change is purely a maintenance update to keep dependencies up to date and does not modify workflow logic or behavior.