### PR TITLE
Fix studio build checkout for private-fork PRs

### DIFF
--- a/.github/workflows/reusable-frontend-publish-unified.yaml
+++ b/.github/workflows/reusable-frontend-publish-unified.yaml
@@ -107,6 +107,13 @@ permissions:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  # Ref for the publish checkout. Fork PRs: the fork can be private (partner
+  # orgs), and this repo's GITHUB_TOKEN cannot read it — fetching the fork
+  # directly fails with "Repository not found". Fetch the PR head as mirrored
+  # into the BASE repo (refs/pull/<n>/head) instead; that ref exists for every
+  # PR regardless of fork visibility. Non-PR runs (push, tags, dispatch) keep
+  # using the branch/tag name as before.
+  CHECKOUT_REF: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && format('refs/pull/{0}/head', github.event.pull_request.number) || github.head_ref || github.ref_name }}
 
 jobs:
   canary-build:
@@ -141,8 +148,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       # No node_modules caching here: `npm ci` deletes node_modules before
       # installing, so a restored cache was discarded anyway — and cache saves

--- a/.github/workflows/reusable-studio-frontend-build-packaged.yaml
+++ b/.github/workflows/reusable-studio-frontend-build-packaged.yaml
@@ -94,6 +94,14 @@ permissions:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  # Ref for the read-only jobs. Fork PRs: the fork can be private (partner
+  # orgs), and this repo's GITHUB_TOKEN cannot read it — fetching the fork
+  # directly fails with "Repository not found". Fetch the PR head as mirrored
+  # into the BASE repo (refs/pull/<n>/head) instead; that ref exists for every
+  # PR regardless of fork visibility. Same-repo runs keep checking out the
+  # branch tip, so jobs ordered after the commit-* jobs still see the freshly
+  # pushed commits.
+  CHECKOUT_REF: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && format('refs/pull/{0}/head', github.event.pull_request.number) || github.head_ref || github.ref_name }}
 
 jobs:
   # Read-only: executes repo-provided code (npm hooks + lint script). Produces a
@@ -108,8 +116,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # This job runs repo-provided code (npm hooks + scripts). Keep no git
           # credentials in .git/config while that code executes; nothing here
           # needs authenticated git after checkout.
@@ -199,8 +206,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # This job runs repo-provided code (npm hooks + scripts). Keep no git
           # credentials in .git/config while that code executes; nothing here
           # needs authenticated git after checkout.
@@ -240,8 +246,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # This job runs repo-provided code (npm hooks + scripts). Keep no git
           # credentials in .git/config while that code executes; nothing here
           # needs authenticated git after checkout.

--- a/.github/workflows/reusable-studio-frontend-build.yaml
+++ b/.github/workflows/reusable-studio-frontend-build.yaml
@@ -96,6 +96,14 @@ permissions:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  # Ref for the read-only jobs. Fork PRs: the fork can be private (partner
+  # orgs), and this repo's GITHUB_TOKEN cannot read it — fetching the fork
+  # directly fails with "Repository not found". Fetch the PR head as mirrored
+  # into the BASE repo (refs/pull/<n>/head) instead; that ref exists for every
+  # PR regardless of fork visibility. Same-repo runs keep checking out the
+  # branch tip, so jobs ordered after the commit-* jobs still see the freshly
+  # pushed commits.
+  CHECKOUT_REF: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && format('refs/pull/{0}/head', github.event.pull_request.number) || github.head_ref || github.ref_name }}
 
 jobs:
   # Read-only: regenerates the API client and captures it as a patch. No write
@@ -112,8 +120,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # Runs repo-provided code (npm hooks + api-client script); no
           # authenticated git needed after checkout.
           persist-credentials: false
@@ -218,8 +225,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # This job runs repo-provided code (npm hooks + lint script). Keep no
           # git credentials in .git/config while that code executes; nothing
           # here needs authenticated git after checkout.
@@ -322,8 +328,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # Runs repo-provided code (npm hooks + typecheck script); no
           # authenticated git needed after checkout.
           persist-credentials: false
@@ -368,8 +373,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # Runs repo-provided code (npm hooks + build script); no authenticated
           # git needed after checkout.
           persist-credentials: false
@@ -481,8 +485,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
         with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.CHECKOUT_REF }}
           # Runs repo-provided code (npm hooks + test script); no authenticated
           # git needed after checkout.
           persist-credentials: false


### PR DESCRIPTION
## Problem

The reusable frontend workflows checked out the PR head **directly from the fork**:

```yaml
ref: ${{ env.BRANCH_NAME }}
repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
```

That works for public forks, but **private forks** (e.g. partner-org forks like `laticrete-pimcore/*`) are not readable by the calling repo's `GITHUB_TOKEN`. The fetch fails with:

```
remote: Repository not found.
fatal: repository 'https://github.com/laticrete-pimcore/data-hub-simple-rest/' not found
```

and the run aborts at the Checkout step. Example failure: [data-hub-simple-rest run 30102786641](https://github.com/pimcore/data-hub-simple-rest/actions/runs/30102786641/job/89513568796?pr=310) (PR from a private partner fork touching `assets/studio/**`).

## Fix

Covers all three affected reusable workflows:

- `reusable-studio-frontend-build.yaml` — api-client, lint, check-types, build, test
- `reusable-studio-frontend-build-packaged.yaml` — lint, check-types, build
- `reusable-frontend-publish-unified.yaml` — publish

Each gets a `CHECKOUT_REF` env used by those jobs, dropping the `repository:` override:

- **Fork PRs** → `refs/pull/<n>/head` fetched from the **base repo**. GitHub mirrors every PR's head commits there, regardless of fork visibility, and the default token can always read its own repo.
- **Same-repo PRs / push / tags / dispatch** → the branch/tag tip, exactly as before. This is deliberate: lint/build are ordered after the `commit-*` jobs so their checkout includes freshly pushed api-client/lint commits — pinning to a SHA would regress that.

The `commit-*` jobs are unchanged: they remain gated to non-fork contexts (`head.repo.full_name == github.repository`) and keep pushing to the real branch. For fork PRs, fixes keep flowing out as patch artifacts as designed. The security posture is unchanged — read-only jobs still run with `contents: read` and `persist-credentials: false`.

## ⚠️ Reviewer decision: fork PRs and canary publishing

In `reusable-frontend-publish-unified.yaml`, the `publish` job previously *happened* to fail at checkout for private-fork PRs. With this fix its checkout succeeds — meaning a fork PR whose run receives `NPM_TOKEN` (private repos with fork-secrets enabled) could publish a canary built from fork code. That was already true for public forks before this PR, so this is not a new class of exposure, but if fork-PR canaries are not intended, the `publish` job should additionally be gated with `github.event.pull_request.head.repo.full_name == github.repository` — happy to add that here if desired.

## Verification

- YAML validated with js-yaml on all three files.
- Behavior table:
  - push / tags / workflow_dispatch → `CHECKOUT_REF` = `github.ref_name` (unchanged)
  - same-repo PR → `github.head_ref` (unchanged)
  - fork PR (public or private) → `refs/pull/<n>/head` from base repo (fixes the failure; also covers deleted-fork PRs where `head.repo` is null)
- Suggested end-to-end check before merge: point a caller in a sandbox repo (`testworkflows-*`) at this branch and open a PR from a private fork; after merge, re-run the failed Studio Frontend Build on data-hub-simple-rest PR #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
