### PR TITLE
Guardrails: exclude pimcore-deployments (guard service account) PRs

### DIFF
--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -3,6 +3,7 @@ name: "Reusable Guardrail: Dev-Team membership"
 # Fast-path / bypass guardrail. Emits `bypass=true` (so the orchestrator skips
 # the issue-link and CI guardrails) when ANY of:
 #   - the PR author is a Dev-Team member, or
+#   - the PR author is the guard service account (pimcore-deployments), or
 #   - the PR carries the override label, or
 #   - a Dev-Team member pressed "Ready for review" on the PR (manual override) —
 #     in which case the override label is added so later runs keep bypassing.
@@ -118,10 +119,16 @@ jobs:
             const bypassedPrs = [];
             for (const pr of prs) {
               // PRs opened before the start date are exempt (checked before any
-              // API call). Then override label, then Dev-Team membership.
+              // API call). Then guard service account author (deterministic, no
+              // API call — team membership of a bot account is not reliable),
+              // then override label, then Dev-Team membership.
               const ageExempt = lib.isExemptByAge(pr);
+              const isGuardBotAuthor = pr.user.login === lib.GUARD_BOT;
               const hasLabel = (pr.labels || []).some((l) => l.name === OVERRIDE_LABEL);
-              let bypass = ageExempt || hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+              let bypass = ageExempt || isGuardBotAuthor || hasLabel || await lib.isDevTeamMember({ github, username: pr.user.login });
+              if (isGuardBotAuthor) {
+                core.info(`PR #${pr.number} authored by ${lib.GUARD_BOT} (guard service account) — exempt.`);
+              }
               if (ageExempt) {
                 core.info(`PR #${pr.number} created ${pr.created_at} is before start date ${lib.START_DATE} — exempt.`);
               }

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -54,7 +54,8 @@ is exempt) no comment is created, and any prior failure comment is removed.
   `2026-07-07`) are exempt — every guardrail skips them, so the policy only
   applies to PRs opened on/after that date.
 - **Bypass**: the membership stage emits `bypass=true` (orchestrator skips both
-  issue-link and CI) when the PR author is a Dev-Team member, the PR carries the
+  issue-link and CI) when the PR author is a Dev-Team member, the PR author is
+  the guard service account (`pimcore-deployments`), the PR carries the
   `guardrails:override` label, or a Dev-Team member overrode it (see below).
   Otherwise non-members must link a valid issue in `pimcore/platform-version`
   via a closing keyword (every closing-keyword reference must be valid) **and**


### PR DESCRIPTION
PRs authored by `pimcore-deployments` (the guard service account, `lib.GUARD_BOT`) now bypass the membership gate explicitly, so the issue-link and CI guardrails never draft its automated PRs (e.g. sync/release PRs).

Previously this relied on `isDevTeamMember()` returning `active` for the service account — an API-dependent check that isn't reliable for bot/service accounts. The new author comparison is deterministic and short-circuits before any API call.

Also documents the new bypass condition in the workflow header comment and `scripts/guardrails/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)