### PR TITLE
Do not report abandoned packages as security vulnerabilities

### DIFF
--- a/.github/workflows/reusable-composer-vulnerabilities.yaml
+++ b/.github/workflows/reusable-composer-vulnerabilities.yaml
@@ -117,7 +117,9 @@ jobs:
               id: vulnerabilities
               run: |
                 set +e
-                VULNERABILITIES=$(composer audit)
+                # Abandoned packages are still listed in the output, but no longer influence the
+                # exit code - otherwise they get reported as security vulnerabilities.
+                VULNERABILITIES=$(composer audit --abandoned=report)
                 EXIT_CODE=$?
                 set -e
 


### PR DESCRIPTION
## Problem

`composer audit` exits non-zero for **abandoned packages** as well as for security advisories, and the `Check for security vulnerabilities` step only looks at the exit code:

```bash
VULNERABILITIES=$(composer audit)
EXIT_CODE=$?
...
if [ "$EXIT_CODE" -ne 0 ]; then
    echo "Security vulnerabilities found!" >> $GITHUB_STEP_SUMMARY
    echo "found=true" >> $GITHUB_OUTPUT   # -> triggers the Teams notify job
```

So any repository whose dependency tree contains an abandoned package is reported as *"Security vulnerabilities found!"* and sends a Teams notification — even when the audit found **zero** advisories.

This is not hypothetical. `pimcore/ee-pimcore@11.5` directly requires `doctrine/annotations` (dropped in `12.3`), which is abandoned. On that branch `composer audit` prints `No security vulnerability advisories found.` and still exits `1`.

## Fix

Pass `--abandoned=report`: abandoned packages stay visible in the audit output, but no longer affect the exit code.

## Verification

Composer 2.10.2 / PHP 8.3, real resolved lock files, comparing the current command against the fixed one:

| Dependencies | before | after | advisories in output | abandoned still listed |
|---|---|---|---|---|
| clean | `0` | `0` | 0 | – |
| abandoned only | `1` ❌ false alarm | **`0`** ✅ | 0 | yes |
| vulnerable (`guzzlehttp/guzzle:6.5.0`) | `1` | **`1`** ✅ | 28 | – |
| vulnerable + abandoned | `1` | **`1`** ✅ | 28 | yes |
| real `ee-pimcore@11.5` HEAD | `1` ❌ false alarm | **`0`** ✅ | 0 | yes |

The important row is the third: real advisories still fail the step, so no vulnerability is masked. Abandoned packages remain in the logged output, so the information is not lost — it just stops being labelled a security vulnerability.

## Scope / risk

- One line changed, plus a comment. No inputs, outputs, or job structure touched.
- Repos currently passing this check are unaffected (their exit code was already `0`).
- The only behaviour change is for repos that were previously failing **solely** because of an abandoned package — exactly the false positives this removes.
- `--abandoned` requires Composer >= 2.6; the workflow installs Composer via `shivammathur/setup-php` without pinning `tools:`, so it gets the latest stable (2.10.x).

## Follow-up

With this merged, `11.5` can be added to `ee-pimcore`'s composer vulnerabilities matrix — currently the `11.5` LTS line is never audited, which leaves the composer-audit release gate permanently UNKNOWN for `11.5.x` releases. Adding it before this fix would have produced a daily false-positive Teams alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
