### PR TITLE
Default the translations model to Sonnet 5

### DIFF
--- a/.github/workflows/reusable-translations.yaml
+++ b/.github/workflows/reusable-translations.yaml
@@ -18,10 +18,10 @@ on:
         type: string
         default: "main"
       model:
-        description: "Model passed to claude-code-action (empty = action default)"
+        description: "Model passed to claude-code-action. Pass an empty string to fall back to the action's own default."
         required: false
         type: string
-        default: ""
+        default: "claude-sonnet-5"
     secrets:
       TRANSLATIONS_GITHUB_TOKEN:
         description: "Bot PAT: contents:write on the calling repo, read on pimcore/claude-code, pull-requests:write"

--- a/examples/translations.yaml
+++ b/examples/translations.yaml
@@ -37,6 +37,7 @@ jobs:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-translations.yaml@main
     with:
       translations_dir: translations
+      # model: claude-sonnet-5   # the default; override to run translations on another model
     secrets:
       TRANSLATIONS_GITHUB_TOKEN: ${{ secrets.TRANSLATIONS_GITHUB_TOKEN }}
       ANTHROPIC_TRANSLATIONS_API_KEY: ${{ secrets.ANTHROPIC_TRANSLATIONS_API_KEY }}


### PR DESCRIPTION
Pins a consistent model across consumer repos instead of tracking whatever claude-code-action defaults to; callers can still override the input, and passing an empty string restores the action default.

Refs pimcore/product-management#1316