### PR TITLE
Guardrails: stop enforcing after a cancelled run, and clear stale failure comments on bypass

### DIFF
--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -7,11 +7,20 @@ name: "PR Guardrails pipeline"
 #
 # Pipeline:
 #   membership  (all events) ─► outputs.bypass
-#   issue-link  (PR events, only when not bypassed)   needs: membership
-#   ci          (PR + check_suite events, only when not bypassed)   needs: membership
+#   issue-link  (PR events, only when membership said "not bypassed")   needs: membership
+#   ci          (PR + check_suite events, only when membership said "not bypassed")   needs: membership
 #
 # Each stage that fails converts the PR to draft and comments. Stages run
 # independently and report individually (a failure does not cancel later stages).
+#
+# The enforcing stages deliberately carry NO always()/!cancelled() in their `if`,
+# so the implied success() gate applies: they run only when `membership` actually
+# produced a verdict. A membership stage that was cancelled (the consumer trigger
+# uses concurrency cancel-in-progress, so back-to-back PR events cancel runs
+# routinely), failed or was skipped emits no outputs, and enforcing on that empty
+# `bypass` would draft Dev-Team members' PRs. Enforcement is instead eventually
+# consistent: the superseding run — and every later edited / synchronize /
+# ready_for_review / check_suite event — re-evaluates the PR.
 
 on:
   workflow_call:
@@ -36,9 +45,11 @@ jobs:
 
   issue-link:
     needs: [membership]
-    # Non-draft PR events only, and only when not bypassed. If membership was
-    # skipped/errored, bypass is empty -> issue-link runs (fail-safe: enforce).
-    if: ${{ always() && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.bypass != 'true' }}
+    # Non-draft PR events only, and only when membership returned a verdict that
+    # is not a bypass. No always()/!cancelled(): success() is implied, so a
+    # cancelled/failed/skipped membership stage skips this guardrail instead of
+    # enforcing on an empty `bypass`.
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-issue-link.yml
     secrets:
       ISSUE_LINK_GUARD_TOKEN: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
@@ -46,8 +57,10 @@ jobs:
   ci:
     needs: [membership]
     # Runs on PR events and on check_suite completion, but never when bypassed.
-    # Empty bypass (membership skipped/errored) -> CI runs (fail-safe).
-    if: ${{ always() && needs.membership.outputs.bypass != 'true' }}
+    # Same gate as issue-link: no always()/!cancelled(), so CI only runs once
+    # membership has concluded. (On draft PR events membership is skipped, which
+    # now skips this job too — it previously ran and no-opped on drafts anyway.)
+    if: ${{ needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-ci.yml
     with:
       # Skip individually-bypassed PRs (e.g. a member PR sharing a check_suite

--- a/.github/workflows/parent-pr-guardrails.yml
+++ b/.github/workflows/parent-pr-guardrails.yml
@@ -7,20 +7,20 @@ name: "PR Guardrails pipeline"
 #
 # Pipeline:
 #   membership  (all events) ─► outputs.bypass
-#   issue-link  (PR events, only when membership said "not bypassed")   needs: membership
-#   ci          (PR + check_suite events, only when membership said "not bypassed")   needs: membership
+#   issue-link  (PR events, only when not bypassed)   needs: membership
+#   ci          (PR + check_suite events, only when not bypassed)   needs: membership
 #
 # Each stage that fails converts the PR to draft and comments. Stages run
 # independently and report individually (a failure does not cancel later stages).
 #
-# The enforcing stages deliberately carry NO always()/!cancelled() in their `if`,
-# so the implied success() gate applies: they run only when `membership` actually
-# produced a verdict. A membership stage that was cancelled (the consumer trigger
-# uses concurrency cancel-in-progress, so back-to-back PR events cancel runs
-# routinely), failed or was skipped emits no outputs, and enforcing on that empty
-# `bypass` would draft Dev-Team members' PRs. Enforcement is instead eventually
-# consistent: the superseding run — and every later edited / synchronize /
-# ready_for_review / check_suite event — re-evaluates the PR.
+# The enforcing stages gate on `!cancelled()` rather than `always()`. always()
+# runs a job even when the run is cancelled, and the consumer trigger uses
+# concurrency cancel-in-progress, so back-to-back PR events cancel runs
+# routinely. A cancelled membership stage emits no outputs, so `bypass` is empty
+# and the "empty means enforce" fail-safe below would draft Dev-Team members'
+# PRs. Cancellation is safe to skip: the superseding run re-evaluates the PR
+# immediately. Every other non-success membership result still enforces, so a
+# broken membership stage can never silently disable the guardrails.
 
 on:
   workflow_call:
@@ -45,11 +45,12 @@ jobs:
 
   issue-link:
     needs: [membership]
-    # Non-draft PR events only, and only when membership returned a verdict that
-    # is not a bypass. No always()/!cancelled(): success() is implied, so a
-    # cancelled/failed/skipped membership stage skips this guardrail instead of
-    # enforcing on an empty `bypass`.
-    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.bypass != 'true' }}
+    # Non-draft PR events only, and only when not bypassed. If membership was
+    # skipped/errored, bypass is empty -> issue-link runs (fail-safe: enforce).
+    # Cancellation is the one exception: a cancelled run (or a cancelled
+    # membership job) never reaches a verdict, and the superseding run will, so
+    # skip instead of enforcing on an empty bypass.
+    if: ${{ !cancelled() && needs.membership.result != 'cancelled' && github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-issue-link.yml
     secrets:
       ISSUE_LINK_GUARD_TOKEN: ${{ secrets.ISSUE_LINK_GUARD_TOKEN }}
@@ -57,10 +58,9 @@ jobs:
   ci:
     needs: [membership]
     # Runs on PR events and on check_suite completion, but never when bypassed.
-    # Same gate as issue-link: no always()/!cancelled(), so CI only runs once
-    # membership has concluded. (On draft PR events membership is skipped, which
-    # now skips this job too — it previously ran and no-opped on drafts anyway.)
-    if: ${{ needs.membership.outputs.bypass != 'true' }}
+    # Empty bypass (membership skipped/errored) -> CI runs (fail-safe), except
+    # after a cancellation — same reasoning as issue-link above.
+    if: ${{ !cancelled() && needs.membership.result != 'cancelled' && needs.membership.outputs.bypass != 'true' }}
     uses: ./.github/workflows/reusable-guardrail-ci.yml
     with:
       # Skip individually-bypassed PRs (e.g. a member PR sharing a check_suite

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -5,7 +5,10 @@ name: "Reusable Guardrail: Dev-Team membership"
 #   - the PR author is a Dev-Team member, or
 #   - the PR carries the override label, or
 #   - a Dev-Team member pressed "Ready for review" on the PR (manual override) —
-#     in which case the override label is added so later runs keep bypassing.
+#     in which case the override label is added so later runs keep bypassing, or
+#   - the PR predates the guardrail start date (age exemption).
+# On a PR event a bypassed PR also has any guardrail failure comments cleared, so
+# a comment from an earlier run never lingers on an exempt PR.
 # This workflow never converts a PR to draft and always succeeds.
 #
 # Called by parent-pr-guardrails.yml in the caller's event context.
@@ -130,15 +133,27 @@ jobs:
                   && await lib.isDevTeamMember({ github, username: actor })) {
                 bypass = true;
                 await lib.addLabel({ github, context, issueNumber: pr.number, label: OVERRIDE_LABEL });
-                // Override clears any guardrail failure comments left by earlier runs.
-                for (const m of ['guardrail:issue-link', 'guardrail:ci-status']) {
-                  await lib.deleteMarkerComment({ github, context, issueNumber: pr.number, marker: m });
-                }
-                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed, failure comments cleared.`);
+                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed.`);
               }
 
               core.info(`PR #${pr.number}: bypass=${bypass}`);
               if (bypass) bypassedPrs.push(pr.number); else allBypass = false;
+
+              // A bypassed PR must not keep a guardrail failure comment, whatever
+              // the reason for the bypass: a member author or age exemption never
+              // triggered cleanup before, so a comment from an earlier run (or from
+              // a run whose membership stage was cancelled) lingered forever.
+              // Restricted to pull_request_target: check_suite fires many times per
+              // push, and a PR event always follows the situations that leave a
+              // stale comment behind.
+              if (bypass && context.eventName === 'pull_request_target') {
+                const deleted = await lib.deleteMarkerComments({
+                  github, context, issueNumber: pr.number, markers: lib.GUARDRAIL_MARKERS,
+                });
+                if (deleted > 0) {
+                  core.info(`PR #${pr.number}: cleared ${deleted} stale guardrail failure comment(s).`);
+                }
+              }
             }
             core.setOutput('bypass', allBypass ? 'true' : 'false');
             core.setOutput('bypassed_prs', JSON.stringify(bypassedPrs));

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -148,12 +148,22 @@ jobs:
               // A bypass reached without any PR event (e.g. the override label
               // applied by hand, which the consumer trigger does not subscribe to)
               // therefore clears on the PR's next event rather than immediately.
+              // Best-effort, and MUST stay that way: this cleanup is cosmetic, but
+              // it now runs on the hot path for every bypassed PR. An unhandled
+              // rejection here (secondary rate limit, transient 5xx) would fail the
+              // job, and a failed membership stage emits no `bypass`, which the
+              // orchestrator's fail-safe reads as "enforce" — drafting the very PR
+              // this stage just decided to exempt. Swallow and warn instead.
               if (bypass && context.eventName === 'pull_request_target') {
-                const deleted = await lib.deleteMarkerComments({
-                  github, context, issueNumber: pr.number, markers: lib.GUARDRAIL_MARKERS,
-                });
-                if (deleted > 0) {
-                  core.info(`PR #${pr.number}: cleared ${deleted} stale guardrail failure comment(s).`);
+                try {
+                  const deleted = await lib.deleteMarkerComments({
+                    github, context, issueNumber: pr.number, markers: lib.GUARDRAIL_MARKERS,
+                  });
+                  if (deleted > 0) {
+                    core.info(`PR #${pr.number}: cleared ${deleted} stale guardrail failure comment(s).`);
+                  }
+                } catch (err) {
+                  core.warning(`PR #${pr.number}: could not clear stale guardrail comments (${err.message}); bypass is unaffected.`);
                 }
               }
             }

--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -144,8 +144,10 @@ jobs:
               // triggered cleanup before, so a comment from an earlier run (or from
               // a run whose membership stage was cancelled) lingered forever.
               // Restricted to pull_request_target: check_suite fires many times per
-              // push, and a PR event always follows the situations that leave a
-              // stale comment behind.
+              // push, so cleaning there would list comments on every CI completion.
+              // A bypass reached without any PR event (e.g. the override label
+              // applied by hand, which the consumer trigger does not subscribe to)
+              // therefore clears on the PR's next event rather than immediately.
               if (bypass && context.eventName === 'pull_request_target') {
                 const deleted = await lib.deleteMarkerComments({
                   github, context, issueNumber: pr.number, markers: lib.GUARDRAIL_MARKERS,

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -47,8 +47,17 @@ is exempt) no comment is created, and any prior failure comment is removed.
 | Stage | Runs when | On failure |
 |-------|-----------|------------|
 | membership | `check_suite`, non-draft PR events, and `converted_to_draft` (skipped on draft PR events) | never drafts, never comments; emits `bypass` |
-| issue-link | non-draft PR events **and** not bypassed | draft + comment (reason + docs link) |
-| ci | all events (PR + `check_suite`) **and** not bypassed | draft + comment (reason) |
+| issue-link | non-draft PR events **and** membership concluded **and** not bypassed | draft + comment (reason + docs link) |
+| ci | all events (PR + `check_suite`) **and** membership concluded **and** not bypassed | draft + comment (reason) |
+
+- **Membership must conclude**: the enforcing stages carry no `always()` /
+  `!cancelled()`, so `success()` is implied on their `needs: [membership]`. A
+  membership stage that was **cancelled** (the consumer trigger uses
+  `cancel-in-progress`, so back-to-back PR events cancel runs routinely), failed
+  or was skipped emits no `bypass`, and enforcing on that empty value would draft
+  exempt members' PRs. Such an event is therefore not enforced; the superseding
+  run and every later `edited` / `synchronize` / `ready_for_review` /
+  `check_suite` event re-evaluate the PR, so enforcement is eventually consistent.
 
 - **Age exemption**: PRs created **before `GUARD_START_DATE`** (default
   `2026-07-07`) are exempt — every guardrail skips them, so the policy only
@@ -58,7 +67,8 @@ is exempt) no comment is created, and any prior failure comment is removed.
   `guardrails:override` label, or a Dev-Team member overrode it (see below).
   Otherwise non-members must link a valid issue in `pimcore/platform-version`
   via a closing keyword (every closing-keyword reference must be valid) **and**
-  pass CI.
+  pass CI. On a PR event a bypassed PR also has any guardrail failure comments
+  removed, so a comment left by an earlier run never lingers on an exempt PR.
 - **ci** requires the PR to be mergeable (no conflicts) and all checks/statuses
   green. It ignores any guardrail checks (name contains `guardrail`) to avoid
   self-deadlock and to not count a sibling guardrail's failure as a CI failure,

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -47,18 +47,17 @@ is exempt) no comment is created, and any prior failure comment is removed.
 | Stage | Runs when | On failure |
 |-------|-----------|------------|
 | membership | `check_suite`, non-draft PR events, and `converted_to_draft` (skipped on draft PR events) | never drafts, never comments; emits `bypass` |
-| issue-link | non-draft PR events **and** membership concluded **and** not bypassed | draft + comment (reason + docs link) |
-| ci | all events (PR + `check_suite`) **and** membership concluded **and** not bypassed | draft + comment (reason) |
+| issue-link | non-draft PR events **and** not bypassed | draft + comment (reason + docs link) |
+| ci | all events (PR + `check_suite`) **and** not bypassed | draft + comment (reason) |
 
-- **Membership must conclude**: the enforcing stages carry no `always()` /
-  `!cancelled()`, so `success()` is implied on their `needs: [membership]`. A
-  membership stage that was **cancelled** (the consumer trigger uses
-  `cancel-in-progress`, so back-to-back PR events cancel runs routinely), failed
-  or was skipped emits no `bypass`, and enforcing on that empty value would draft
-  exempt members' PRs. Such an event is therefore not enforced; the superseding
-  run and every later `edited` / `synchronize` / `ready_for_review` /
-  `check_suite` event re-evaluate the PR, so enforcement is eventually consistent.
-
+- **Cancellation**: the enforcing stages gate on `!cancelled()`, never `always()`
+  — `always()` runs a job *even when the run is cancelled*, and the consumer
+  trigger uses `cancel-in-progress`, so back-to-back PR events cancel runs
+  routinely. A cancelled membership stage emits no `bypass`, and enforcing on
+  that empty value drafts exempt members' PRs. Cancellation is safe to skip
+  because the superseding run re-evaluates the PR immediately. Every **other**
+  non-success membership result (failed, skipped) still enforces, so a broken
+  membership stage can never silently disable the guardrails.
 - **Age exemption**: PRs created **before `GUARD_START_DATE`** (default
   `2026-07-07`) are exempt — every guardrail skips them, so the policy only
   applies to PRs opened on/after that date.
@@ -67,8 +66,14 @@ is exempt) no comment is created, and any prior failure comment is removed.
   `guardrails:override` label, or a Dev-Team member overrode it (see below).
   Otherwise non-members must link a valid issue in `pimcore/platform-version`
   via a closing keyword (every closing-keyword reference must be valid) **and**
-  pass CI. On a PR event a bypassed PR also has any guardrail failure comments
-  removed, so a comment left by an earlier run never lingers on an exempt PR.
+  pass CI.
+- **Bypass clears failure comments**: on a `pull_request_target` event a bypassed
+  PR also has every marker comment in `lib.GUARDRAIL_MARKERS` removed, so a
+  comment left by an earlier run never lingers on an exempt PR. Not done on
+  `check_suite` (it fires many times per push, and a PR event always follows the
+  situations that leave a stale comment behind). Applying the
+  `guardrails:override` label by hand is the one bypass the consumer trigger does
+  not subscribe to — its comments clear on the PR's next event.
 - **ci** requires the PR to be mergeable (no conflicts) and all checks/statuses
   green. It ignores any guardrail checks (name contains `guardrail`) to avoid
   self-deadlock and to not count a sibling guardrail's failure as a CI failure,
@@ -105,6 +110,8 @@ does not.
 1. Add `reusable-guardrail-<x>.yml` here (`workflow_call`, one token secret).
 2. Add a job to `parent-pr-guardrails.yml` and pass it the token.
 3. If it needs a new token, add **one** org-level secret.
+4. If it posts a failure comment, add its marker to `GUARDRAIL_MARKERS` in
+   `lib.js` — otherwise its comments are never cleared when a PR is bypassed.
 
 No consumer repo is touched.
 

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -21,6 +21,10 @@ const GUARD_BOT = process.env.GUARD_BOT_LOGIN || 'pimcore-deployments';
 // disables the date gate. ISO date (UTC) — e.g. "2026-07-07".
 const START_DATE = process.env.GUARD_START_DATE || '2026-07-07';
 
+// Marker tags of every guardrail that posts a failure comment. Kept here so a
+// bypass can clear all of them without each caller re-listing the markers.
+const GUARDRAIL_MARKERS = ['guardrail:issue-link', 'guardrail:ci-status'];
+
 // GitHub's supported issue-closing keywords.
 const CLOSING_KEYWORDS = [
   'close', 'closes', 'closed',
@@ -187,12 +191,17 @@ async function upsertComment({ github, context, issueNumber, marker, body }) {
   }
 }
 
-/** Delete the marker comment if present (used when a guardrail now passes, so a
- *  stale failure comment does not linger). No-op when there is nothing to remove. */
-async function deleteMarkerComment({ github, context, issueNumber, marker }) {
+/**
+ * Delete the marker comments of one or more guardrails (used when a guardrail now
+ * passes, or when a PR turns out to be bypassed, so a stale failure comment does
+ * not linger). Lists the comments once for all markers. No-op when there is
+ * nothing to remove. Returns the number of comments deleted.
+ */
+async function deleteMarkerComments({ github, context, issueNumber, markers }) {
   const { owner, repo } = context.repo;
   const issue_number = issueNumber || context.payload.pull_request.number;
-  const tag = `<!-- ${marker} -->`;
+  const tags = (Array.isArray(markers) ? markers : [markers]).map((m) => `<!-- ${m} -->`);
+  if (tags.length === 0) return 0;
 
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner,
@@ -204,11 +213,17 @@ async function deleteMarkerComment({ github, context, issueNumber, marker }) {
   // duplicates do not leave a stale comment behind and human comments containing
   // the marker are never deleted.
   const matches = comments.filter(
-    (c) => c.user && c.user.login === GUARD_BOT && c.body && c.body.includes(tag),
+    (c) => c.user && c.user.login === GUARD_BOT && c.body && tags.some((t) => c.body.includes(t)),
   );
   for (const c of matches) {
     await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
   }
+  return matches.length;
+}
+
+/** Single-marker convenience wrapper around `deleteMarkerComments`. */
+async function deleteMarkerComment({ github, context, issueNumber, marker }) {
+  return deleteMarkerComments({ github, context, issueNumber, markers: [marker] });
 }
 
 /** Add a label to a PR/issue, creating the label in the repo if it is missing. */
@@ -254,6 +269,7 @@ module.exports = {
   GUARD_BOT,
   START_DATE,
   CLOSING_KEYWORDS,
+  GUARDRAIL_MARKERS,
   REVALIDATE_HINT,
   isExemptByAge,
   isDevTeamMember,
@@ -263,6 +279,7 @@ module.exports = {
   convertToDraft,
   upsertComment,
   deleteMarkerComment,
+  deleteMarkerComments,
   addLabel,
   removeLabel,
 };

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -195,7 +195,8 @@ async function upsertComment({ github, context, issueNumber, marker, body }) {
  * Delete the marker comments of one or more guardrails (used when a guardrail now
  * passes, or when a PR turns out to be bypassed, so a stale failure comment does
  * not linger). Lists the comments once for all markers. No-op when there is
- * nothing to remove. Returns the number of comments deleted.
+ * nothing to remove. A comment another job deleted first (404) is not an error.
+ * Returns the number of comments deleted.
  */
 async function deleteMarkerComments({ github, context, issueNumber, markers }) {
   const { owner, repo } = context.repo;
@@ -215,10 +216,18 @@ async function deleteMarkerComments({ github, context, issueNumber, markers }) {
   const matches = comments.filter(
     (c) => c.user && c.user.login === GUARD_BOT && c.body && tags.some((t) => c.body.includes(t)),
   );
+  let deleted = 0;
   for (const c of matches) {
-    await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
+    try {
+      await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
+      deleted++;
+    } catch (err) {
+      // Another guardrail job may have deleted the same comment first (a
+      // check_suite run and a PR run can overlap). Nothing left to do.
+      if (err.status !== 404) throw err;
+    }
   }
-  return matches.length;
+  return deleted;
 }
 
 /** Single-marker convenience wrapper around `deleteMarkerComments`. */


### PR DESCRIPTION
Fixes https://github.com/pimcore/DevOps-Tasks/issues/18

Supersedes #153, which is now folded in here.

### Problem

Reported as *"bypass of employees does not work"*: the membership stage resolves `bypass` correctly, yet the issue-link guardrail still converts a Dev-Team member's PR to draft and demands a `pimcore/platform-version` link.

The bypass logic is fine. The defect is the orchestrator's job gating:

```yaml
if: ${{ always() && ... && needs.membership.outputs.bypass != 'true' }}
```

[`always()` runs a job even when the workflow run is cancelled](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always), and the consumer trigger (`pr-guardrails.yml`) uses `concurrency: cancel-in-progress: true`. Back-to-back PR events therefore cancel runs routinely, and when that happens:

1. `membership` is cancelled -> it emits **no outputs**
2. `always()` dispatches `issue-link` / `ci` anyway
3. `needs.membership.outputs.bypass` is `''`, so `'' != 'true'` -> the *"fail-safe: enforce"* branch fires
4. an exempt member's PR is drafted with a failure comment

### Evidence

The run that posted the comment named in the issue - portal-engine [run 30367533976](https://github.com/pimcore/portal-engine/actions/runs/30367533976), on [portal-engine#931](https://github.com/pimcore/portal-engine/pull/931) (author is a Dev-Team member):

| job | conclusion | window |
|---|---|---|
| `membership` | **cancelled** - 0 steps executed | 14:16:21 -> 14:16:25 |
| `issue-link` | **failure** -> drafted the PR + commented | 14:16:29 -> 14:16:37 |
| `ci` | success | 14:16:37 -> 14:16:46 |

The guardrail comment on that PR is timestamped `14:16:35` - inside the `issue-link` window. The superseding [run 30367540853](https://github.com/pimcore/portal-engine/actions/runs/30367540853) then ran `membership` successfully and **skipped** `issue-link`, which is the *"membership check and output is set correct with bypass"* the reporter observed.

Not a one-off - cancelled runs where `always()` let an enforcing guardrail fire (last ~100 runs per repo, ~1 week):

| repo | run | fallout |
|---|---|---|
| `pimcore/pimcore` | [30288422142](https://github.com/pimcore/pimcore/actions/runs/30288422142) | `issue-link` failure |
| `pimcore/portal-engine` | [30367533976](https://github.com/pimcore/portal-engine/actions/runs/30367533976) | `issue-link` failure |
| `pimcore/portal-engine` | [30553249721](https://github.com/pimcore/portal-engine/actions/runs/30553249721) | `issue-link` **and** `ci` failure |
| `pimcore/studio-backend-bundle` | [30553291310](https://github.com/pimcore/studio-backend-bundle/actions/runs/30553291310) | `issue-link` failure |
| `pimcore/studio-ui-bundle` | [30462555013](https://github.com/pimcore/studio-ui-bundle/actions/runs/30462555013) | `issue-link` failure |

In run 30553249721 `membership` was cancelled at 14:46:11 and `issue-link` still started at **14:56:31** - ten minutes later. `always()` keeps dispatching queued jobs long after cancellation.

### Fix 1 - gate on `!cancelled()`, not `always()`

```yaml
if: ${{ !cancelled() && needs.membership.result != 'cancelled' && ... }}
```

`!cancelled()` covers a cancelled run; `needs.membership.result != 'cancelled'` also covers a membership job cancelled on its own.

| `membership` result | before | after |
|---|---|---|
| success, `bypass=true` | skip | skip (unchanged) |
| success, `bypass=false` | enforce | enforce (unchanged) |
| **cancelled** | **enforce -> the bug** | **skip** |
| failed | enforce | enforce (unchanged) |
| skipped (draft PR event) | enforce (`ci` no-ops internally on drafts) | unchanged |

Only cancellation caused the false positives, so only cancellation stops enforcing. An earlier revision of this PR dropped `always()` entirely, which would also have failed open on a genuine membership failure - and unlike a cancellation, a failure has no superseding run, so the guardrails would have stayed silently disabled with no signal beyond a "skipped" job. That was walked back after review (thanks Copilot). Measured across five repos: **210 membership executions, 15 cancelled, 0 failed** - so the narrower gate costs nothing observable while keeping the fail-closed default intact.

### Fix 2 - clear stale failure comments whenever a PR is bypassed

Cleanup previously ran **only** in the manual `ready_for_review` override branch, so a PR bypassed because its author is a member never had its comments cleared. Once a failure comment was posted it stayed forever - [portal-engine#931 still carries the comment](https://github.com/pimcore/portal-engine/pull/931#issuecomment-5105310344) that triggered the DevOps-Tasks issue, after merge.

Fix 1 stops those comments being posted; this makes an existing one clear itself.

- `reusable-guardrail-membership.yml`: clear failure comments for **every** bypassed PR, on `pull_request_target` events. `check_suite` is excluded because it fires many times per push. A bypass reached without any PR event (applying `guardrails:override` by hand, which the consumer trigger does not subscribe to) clears on the PR's next event rather than immediately - documented, not silently assumed.
- The `converted_to_draft` early-return is deliberately untouched: retraction means the guardrails must re-apply, so its comments have to stay.
- `lib.js`: new `deleteMarkerComments({ markers })` lists comments **once** for all markers instead of once per marker, keeps the guard-bot author filter so human comments quoting a marker are never deleted, and returns the number deleted. `deleteMarkerComment` stays as a single-marker wrapper, so `reusable-guardrail-issue-link.yml` and `reusable-guardrail-ci.yml` are untouched. Marker strings move into `lib.GUARDRAIL_MARKERS`, and the "adding a new guardrail" checklist now tells you to register there.
- The cleanup is **best-effort and must stay that way.** It is cosmetic, but it now runs on the hot path — every bypassed PR, every `pull_request_target` event. An unhandled rejection there (secondary rate limit, transient 5xx, or a 404 when a concurrent guardrail job deleted the same comment first) would fail the membership job; a failed membership stage emits no `bypass`, and the fail-safe in Fix 1 reads an empty `bypass` as *enforce* — so a cosmetic cleanup error would draft the very PR the stage just exempted, reintroducing this bug through a different path. The call site swallows and warns, and a 404 from `deleteComment` is treated as "already gone". The membership stage keeps its documented contract: never drafts, always succeeds.

No permission change: the membership job already declares `issues: write`.

**Not doing:** auto-flipping a wrongly-drafted PR back to Ready. The guardrail cannot tell whether the bot or the author drafted it, so un-drafting risks overriding an intentional draft.

### Scope

All consumer repos pin `parent-pr-guardrails.yml@main`, so merging here fixes every repo at once. No consumer repo is touched and no sync run is needed.

Test-merged against #136 (approved, touches the same three files): **no conflict**. The pipeline summary block and the Bypass bullet were deliberately left untouched here so the two PRs stay independent.

### Verification

- All workflows parse; the three `if` expressions are as intended and no `always()` remains outside comments.
- `node --check` on `lib.js` and on the `github-script` body extracted from the membership workflow (async-wrapped, as github-script runs it).
- Smoke test of `deleteMarkerComments` against a fake octokit: both markers cleared in a **single** `listComments` call, human comments quoting a marker and unrelated bot comments left alone, single-marker wrapper still deletes exactly one, bare-string marker accepted, empty marker list never lists comments, a 404 is tolerated without being counted while the remaining matches are still deleted, and a non-404 still propagates to the caller (which swallows it).
- Test-merged against #136 after every push — clean.
- After merge: force a cancellation on a scratch PR (two description edits within ~5s) and confirm the cancelled run reports `issue-link` / `ci` as **skipped** instead of **failure**, with no draft conversion and no comment. Known-bad baseline to diff against: portal-engine run `30553249721` (`cancelled` / `failure` / `failure`).
- Confirm a non-member PR on an uncancelled run still fails `issue-link` (no enforcement regression), and that a bypassed member PR carrying a stale comment has it removed on the next PR event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
