### PR TITLE
Guardrails: clear stale failure comments whenever a PR is bypassed

### DIFF
--- a/.github/workflows/reusable-guardrail-membership.yml
+++ b/.github/workflows/reusable-guardrail-membership.yml
@@ -5,7 +5,10 @@ name: "Reusable Guardrail: Dev-Team membership"
 #   - the PR author is a Dev-Team member, or
 #   - the PR carries the override label, or
 #   - a Dev-Team member pressed "Ready for review" on the PR (manual override) —
-#     in which case the override label is added so later runs keep bypassing.
+#     in which case the override label is added so later runs keep bypassing, or
+#   - the PR predates the guardrail start date (age exemption).
+# On a PR event a bypassed PR also has any guardrail failure comments cleared, so
+# a comment from an earlier run never lingers on an exempt PR.
 # This workflow never converts a PR to draft and always succeeds.
 #
 # Called by parent-pr-guardrails.yml in the caller's event context.
@@ -130,15 +133,27 @@ jobs:
                   && await lib.isDevTeamMember({ github, username: actor })) {
                 bypass = true;
                 await lib.addLabel({ github, context, issueNumber: pr.number, label: OVERRIDE_LABEL });
-                // Override clears any guardrail failure comments left by earlier runs.
-                for (const m of ['guardrail:issue-link', 'guardrail:ci-status']) {
-                  await lib.deleteMarkerComment({ github, context, issueNumber: pr.number, marker: m });
-                }
-                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed, failure comments cleared.`);
+                core.info(`Override: @${actor} (Dev-Team) marked PR #${pr.number} ready — guardrails bypassed.`);
               }
 
               core.info(`PR #${pr.number}: bypass=${bypass}`);
               if (bypass) bypassedPrs.push(pr.number); else allBypass = false;
+
+              // A bypassed PR must not keep a guardrail failure comment, whatever
+              // the reason for the bypass: a member author or age exemption never
+              // triggered cleanup before, so a comment from an earlier run (or from
+              // a run whose membership stage was cancelled) lingered forever.
+              // Restricted to pull_request_target: check_suite fires many times per
+              // push, and a PR event always follows the situations that leave a
+              // stale comment behind.
+              if (bypass && context.eventName === 'pull_request_target') {
+                const deleted = await lib.deleteMarkerComments({
+                  github, context, issueNumber: pr.number, markers: lib.GUARDRAIL_MARKERS,
+                });
+                if (deleted > 0) {
+                  core.info(`PR #${pr.number}: cleared ${deleted} stale guardrail failure comment(s).`);
+                }
+              }
             }
             core.setOutput('bypass', allBypass ? 'true' : 'false');
             core.setOutput('bypassed_prs', JSON.stringify(bypassedPrs));

--- a/scripts/guardrails/README.md
+++ b/scripts/guardrails/README.md
@@ -47,8 +47,17 @@ is exempt) no comment is created, and any prior failure comment is removed.
 | Stage | Runs when | On failure |
 |-------|-----------|------------|
 | membership | `check_suite`, non-draft PR events, and `converted_to_draft` (skipped on draft PR events) | never drafts, never comments; emits `bypass` |
-| issue-link | non-draft PR events **and** not bypassed | draft + comment (reason + docs link) |
-| ci | all events (PR + `check_suite`) **and** not bypassed | draft + comment (reason) |
+| issue-link | non-draft PR events **and** membership concluded **and** not bypassed | draft + comment (reason + docs link) |
+| ci | all events (PR + `check_suite`) **and** membership concluded **and** not bypassed | draft + comment (reason) |
+
+- **Membership must conclude**: the enforcing stages carry no `always()` /
+  `!cancelled()`, so `success()` is implied on their `needs: [membership]`. A
+  membership stage that was **cancelled** (the consumer trigger uses
+  `cancel-in-progress`, so back-to-back PR events cancel runs routinely), failed
+  or was skipped emits no `bypass`, and enforcing on that empty value would draft
+  exempt members' PRs. Such an event is therefore not enforced; the superseding
+  run and every later `edited` / `synchronize` / `ready_for_review` /
+  `check_suite` event re-evaluate the PR, so enforcement is eventually consistent.
 
 - **Age exemption**: PRs created **before `GUARD_START_DATE`** (default
   `2026-07-07`) are exempt — every guardrail skips them, so the policy only
@@ -58,7 +67,8 @@ is exempt) no comment is created, and any prior failure comment is removed.
   `guardrails:override` label, or a Dev-Team member overrode it (see below).
   Otherwise non-members must link a valid issue in `pimcore/platform-version`
   via a closing keyword (every closing-keyword reference must be valid) **and**
-  pass CI.
+  pass CI. On a PR event a bypassed PR also has any guardrail failure comments
+  removed, so a comment left by an earlier run never lingers on an exempt PR.
 - **ci** requires the PR to be mergeable (no conflicts) and all checks/statuses
   green. It ignores any guardrail checks (name contains `guardrail`) to avoid
   self-deadlock and to not count a sibling guardrail's failure as a CI failure,

--- a/scripts/guardrails/lib.js
+++ b/scripts/guardrails/lib.js
@@ -21,6 +21,10 @@ const GUARD_BOT = process.env.GUARD_BOT_LOGIN || 'pimcore-deployments';
 // disables the date gate. ISO date (UTC) — e.g. "2026-07-07".
 const START_DATE = process.env.GUARD_START_DATE || '2026-07-07';
 
+// Marker tags of every guardrail that posts a failure comment. Kept here so a
+// bypass can clear all of them without each caller re-listing the markers.
+const GUARDRAIL_MARKERS = ['guardrail:issue-link', 'guardrail:ci-status'];
+
 // GitHub's supported issue-closing keywords.
 const CLOSING_KEYWORDS = [
   'close', 'closes', 'closed',
@@ -187,12 +191,17 @@ async function upsertComment({ github, context, issueNumber, marker, body }) {
   }
 }
 
-/** Delete the marker comment if present (used when a guardrail now passes, so a
- *  stale failure comment does not linger). No-op when there is nothing to remove. */
-async function deleteMarkerComment({ github, context, issueNumber, marker }) {
+/**
+ * Delete the marker comments of one or more guardrails (used when a guardrail now
+ * passes, or when a PR turns out to be bypassed, so a stale failure comment does
+ * not linger). Lists the comments once for all markers. No-op when there is
+ * nothing to remove. Returns the number of comments deleted.
+ */
+async function deleteMarkerComments({ github, context, issueNumber, markers }) {
   const { owner, repo } = context.repo;
   const issue_number = issueNumber || context.payload.pull_request.number;
-  const tag = `<!-- ${marker} -->`;
+  const tags = (Array.isArray(markers) ? markers : [markers]).map((m) => `<!-- ${m} -->`);
+  if (tags.length === 0) return 0;
 
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner,
@@ -204,11 +213,17 @@ async function deleteMarkerComment({ github, context, issueNumber, marker }) {
   // duplicates do not leave a stale comment behind and human comments containing
   // the marker are never deleted.
   const matches = comments.filter(
-    (c) => c.user && c.user.login === GUARD_BOT && c.body && c.body.includes(tag),
+    (c) => c.user && c.user.login === GUARD_BOT && c.body && tags.some((t) => c.body.includes(t)),
   );
   for (const c of matches) {
     await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
   }
+  return matches.length;
+}
+
+/** Single-marker convenience wrapper around `deleteMarkerComments`. */
+async function deleteMarkerComment({ github, context, issueNumber, marker }) {
+  return deleteMarkerComments({ github, context, issueNumber, markers: [marker] });
 }
 
 /** Add a label to a PR/issue, creating the label in the repo if it is missing. */
@@ -254,6 +269,7 @@ module.exports = {
   GUARD_BOT,
   START_DATE,
   CLOSING_KEYWORDS,
+  GUARDRAIL_MARKERS,
   REVALIDATE_HINT,
   isExemptByAge,
   isDevTeamMember,
@@ -263,6 +279,7 @@ module.exports = {
   convertToDraft,
   upsertComment,
   deleteMarkerComment,
+  deleteMarkerComments,
   addLabel,
   removeLabel,
 };


### PR DESCRIPTION
Follow-up to #152 — second defect found while investigating https://github.com/pimcore/DevOps-Tasks/issues/18. **Merge after #152**, whose behaviour this PR's README section documents. The two PRs touch disjoint files, so they merge in either order without conflict.

### Problem

`reusable-guardrail-membership.yml` clears guardrail failure comments **only** in the manual `ready_for_review` override branch. A PR bypassed for any other reason — Dev-Team member author, the `guardrails:override` label, the age exemption — never gets cleanup.

So once a 🚫 comment has been posted it stays on the PR forever. [portal-engine#931](https://github.com/pimcore/portal-engine/pull/931) still carries [the comment](https://github.com/pimcore/portal-engine/pull/931#issuecomment-5105310344) that triggered the DevOps-Tasks issue, even though the guardrail correctly bypassed the PR seconds later and the PR has since been merged.

#152 stops those comments from being posted in the first place; this PR makes an existing one clear itself.

### Change

**`reusable-guardrail-membership.yml`** — clear the failure comments for every bypassed PR, not just the manual-override case.

Restricted to `pull_request_target`: `check_suite` fires many times per push, while a PR event always follows the situations that leave a stale comment behind. This preserves the old override behaviour exactly — the override branch is reachable only via `ready_for_review`, which is a `pull_request_target` event.

The `converted_to_draft` early-return is deliberately left alone: retraction means the guardrails must re-apply, so its comments have to stay.

**`scripts/guardrails/lib.js`** — add `deleteMarkerComments({ github, context, issueNumber, markers })`:

- lists the comments **once** for all markers instead of once per marker (the old override branch made two paginated `listComments` calls)
- keeps the existing guard-bot author filter, so a human comment quoting a marker is never deleted
- returns the number deleted, so the workflow only logs when it actually removed something
- `deleteMarkerComment` stays as a single-marker wrapper — `reusable-guardrail-issue-link.yml` and `reusable-guardrail-ci.yml` are untouched

The marker list moves into `lib.GUARDRAIL_MARKERS` so it is no longer hard-coded in the membership workflow.

No permission change: the job already declares `issues: write`.

**Not doing:** auto-flipping a wrongly-drafted PR back to Ready. The guardrail cannot tell whether the bot or the author drafted it, so un-drafting risks overriding an intentional draft.

### Verification

- `node --check scripts/guardrails/lib.js`; the embedded `github-script` body extracted from the workflow parses as an async function body (how github-script runs it); all three guardrail workflows parse as YAML.
- Smoke test of the new helper against a fake octokit — asserts that both markers are cleared in a **single** `listComments` call, that a human comment containing the marker and unrelated bot comments are left alone, that the single-marker wrapper still deletes exactly one, that a bare string marker is accepted, and that an empty marker list never even lists comments.
- After merge: on a member PR carrying a stale 🚫 comment, trigger any PR event and confirm the comment is deleted while the PR stays ready — and that a non-member PR's failure comment is *not* cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)