### PR TITLE
[Symfony 8] Add reusable Symfony 8 compatibility check

### DIFF
--- a/.github/workflows/reusable-symfony8-compat.yaml
+++ b/.github/workflows/reusable-symfony8-compat.yaml
@@ -1,0 +1,117 @@
+name: "Reusable Symfony 8 compatibility check"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Central, growing Symfony-8-compatibility test suite for all Pimcore repos.
+#
+# Repos subscribe with a thin caller workflow (.github/workflows/symfony8-compat.yaml):
+#
+#     jobs:
+#       symfony8-compat:
+#         uses: pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main
+#
+# HOW TO ADD A TEST (after a fix sweep has merged across the repos):
+#   Append ONE entry to jobs.api-scan.strategy.matrix.include below:
+#     - id:    kebab-case identifier          (becomes the check name on the PR)
+#       title: what is banned and since when  (one line, human-readable)
+#       regex: extended regex, PRECISE FORM ONLY (see rules below)
+#       hint:  what to use instead            (shown in the PR error annotation)
+#   Nothing else changes - the scan step below is generic.
+#
+# PATTERN RULES:
+#   - Match the precise syntactic form (attribute call, import line), never a bare
+#     word: Pimcore names classes after Symfony concepts (TaggedIteratorAdapter,
+#     TaggedIteratorHydrator, ...) and those must never match.
+#   - One deprecated API often needs two entries: the usage and the import.
+#   - Non-grep checks (composer installability, PHPStan) are added as sibling
+#     jobs - see the scaffold at the bottom - not as matrix entries.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+    workflow_call:
+        inputs:
+            source-dirs:
+                required: false
+                default: "src lib models bundles config"
+                type: string
+                description: Space-separated dirs to scan; missing ones are skipped
+
+permissions:
+  contents: read
+
+jobs:
+    api-scan:
+        name: "api-scan (${{ matrix.id }})"
+        runs-on: "ubuntu-latest"
+        strategy:
+            fail-fast: false            # every rule reports; none masks another
+            matrix:
+                include:
+                    # ── Symfony 8.0: #[TaggedIterator] removed ────────────────────
+                    - id: "tagged-iterator-attribute"
+                      title: "#[TaggedIterator] attribute (removed in Symfony 8.0)"
+                      regex: '#\[TaggedIterator\('
+                      hint: 'Use #[AutowireIterator] - identical constructor, drop-in rename'
+                    - id: "tagged-iterator-import"
+                      title: "TaggedIterator import (removed in Symfony 8.0)"
+                      regex: 'use Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator;'
+                      hint: 'Use Symfony\Component\DependencyInjection\Attribute\AutowireIterator'
+
+                    # ── NEXT ENTRIES LAND HERE, one block per completed fix sweep ──
+
+        steps:
+            - uses: actions/checkout@v5.0.1
+
+            - name: "${{ matrix.title }}"
+              shell: bash
+              env:
+                  SCAN_ID: ${{ matrix.id }}
+                  SCAN_TITLE: ${{ matrix.title }}
+                  SCAN_REGEX: ${{ matrix.regex }}
+                  SCAN_HINT: ${{ matrix.hint }}
+                  SOURCE_DIRS: ${{ inputs.source-dirs }}
+              run: |
+                  DIRS=""
+                  for d in $SOURCE_DIRS; do
+                      [ -d "$d" ] && DIRS="$DIRS $d"
+                  done
+                  if [ -z "$DIRS" ]; then
+                      echo "No source dirs out of '$SOURCE_DIRS' present - nothing to scan."
+                      exit 0
+                  fi
+
+                  echo "Scanning$DIRS for: $SCAN_TITLE"
+                  hits=$(grep -rEn --include='*.php' -e "$SCAN_REGEX" $DIRS 2>/dev/null || true)
+
+                  if [ -z "$hits" ]; then
+                      echo "clean - no match for '$SCAN_REGEX'"
+                      exit 0
+                  fi
+
+                  while IFS= read -r hit; do
+                      file="${hit%%:*}"
+                      rest="${hit#*:}"
+                      line="${rest%%:*}"
+                      echo "::error file=$file,line=$line::Symfony 8 incompatibility ($SCAN_ID): $SCAN_HINT"
+                  done <<< "$hits"
+
+                  count=$(printf '%s\n' "$hits" | wc -l | tr -d ' ')
+                  echo "::notice::$SCAN_TITLE - $count occurrence(s) found"
+                  exit 1
+
+    # ── Scaffold for future NON-GREP checks ──────────────────────────────────────
+    # Grep rules belong in the matrix above. Checks that need PHP, Composer or a
+    # static analyser get their own job here, so they stay separately named on the PR.
+    #
+    # composer-symfony8-installability:
+    #     name: "composer why-not symfony/http-kernel ^8"
+    #     runs-on: "ubuntu-latest"
+    #     steps:
+    #         - uses: actions/checkout@v5.0.1
+    #         - ...   # informational until pimcore/pimcore itself targets symfony ^8.1
+    #
+    # phpstan-symfony-deprecations:
+    #     name: "PHPStan deprecation scan limited to Symfony\\* APIs"
+    #     runs-on: "ubuntu-latest"
+    #     steps:
+    #         - uses: actions/checkout@v5.0.1
+    #         - ...   # needs composer install; add once the deprecation baseline is empty


### PR DESCRIPTION
## What

Adds `.github/workflows/reusable-symfony8-compat.yaml` — a `workflow_call` entry point that all Pimcore
platform repos subscribe to, so they are continuously tested for **Symfony 8 compatibility** on every PR.

This is the first of 38 PRs in the Symfony 8 migration step 1 series (see *Context*). It contains **only**
the new workflow file; nothing existing is touched.

## Why here

The check has to live in one central place so the rule set can grow with the migration instead of being
copy-pasted into 37 repos. `workflows-collection-public` is public, which is what makes it callable from
the private `ee-*` bundles too.

## How it grows (the ratchet)

Every test is **one self-describing `matrix.include` entry** — `id`, `title`, `regex`, `hint`:

```yaml
- id: "tagged-iterator-attribute"
  title: "#[TaggedIterator] attribute (removed in Symfony 8.0)"
  regex: '#\[TaggedIterator\('
  hint: 'Use #[AutowireIterator] - identical constructor, drop-in rename'
```

- Each entry renders as its **own named check** on the PR (`api-scan (tagged-iterator-attribute)`), with
  `fail-fast: false`, so a red PR names the exact rule it violates and no rule masks another.
- Hits are reported as GitHub **error annotations on the offending line**, carrying the fix hint.
- The scan step itself is generic — **adding a test never means touching bash**.
- Checks that cannot be expressed as a grep (Composer installability, a PHPStan deprecation scan) get
  their own sibling job; a commented scaffold at the bottom of the file marks where.

The workflow header documents this recipe, plus the pattern rules learned the hard way during the
analysis: match the **precise syntactic form**, never a bare word — Pimcore names classes after Symfony
concepts (`TaggedIteratorAdapter`, `TaggedIteratorHydrator`, `TaggedIteratorOutputFormatterLoader`), and a
sloppy pattern flags those. A raw word-grep over the platform reported 114 hits where only 24 were real.

## Initial rule set

| id | bans | since |
|---|---|---|
| `tagged-iterator-attribute` | `#[TaggedIterator(` | removed in Symfony **8.0** |
| `tagged-iterator-import` | `use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;` | removed in Symfony **8.0** |

Both are fixed across the platform by the accompanying
`[Symfony 8] Replace deprecated #[TaggedIterator] with #[AutowireIterator]` PRs (9 repos, 40 usages) — a
verified pure rename: `TaggedIterator` and `AutowireIterator` have identical constructors, and
`TaggedIterator::__construct()` only triggers a deprecation and forwards to its parent.

## Input

`source-dirs` (optional, default `src lib models bundles config`) — space-separated; missing directories
are skipped, so the same defaults work for a small bundle and for `pimcore/pimcore`.

## Verification

- YAML parses; matrix shape validated (2 entries, exactly the 4 documented keys each).
- Positive test: both regexes were run against real code on `2026.x` and found the known usages
  (`studio-ui-bundle` 1, `generic-data-index-bundle` 3, `data-hub-file-export` 2 — matching the analysis).
- Negative test: the attribute regex reports **0** in `data-hub-webhooks`, which contains a class named
  `TaggedIteratorOutputFormatterLoader` — class names are correctly not matched.
- Follows the repo conventions: `reusable-*.yaml`, `permissions: contents: read`, `actions/checkout@v5.0.1`.

## Context

Derived from the Symfony 7.4 → 8 readiness analysis of all 37 platform SBOM repos
(`pimcore/platform-version`, `migration-analysis/SUMMARY.md` + `VALIDATION.md`). Once this is merged, the
37 bundle PRs that add the thin caller workflow can resolve `@main` and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
