### PR TITLE
[Symfony 8] Ban concrete RateLimiterFactory injection (use the interface)

### DIFF
--- a/.github/workflows/reusable-symfony8-compat.yaml
+++ b/.github/workflows/reusable-symfony8-compat.yaml
@@ -84,6 +84,20 @@ jobs:
                       regex: 'use Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator;'
                       hint: 'Use Symfony\Component\DependencyInjection\Attribute\AutowireIterator'
 
+                    # ── Symfony 8.0: autowiring aliases for RateLimiterFactory removed ──
+                    # Both patterns are anchored so the FIXED form does not match: the interface
+                    # name STARTS with the banned one (RateLimiterFactoryInterface), and there are
+                    # decoys ending in it (McpAuthRateLimiterFactory, CompoundRateLimiterFactory).
+                    # Return types are not matched (no "$" follows) - the import rule covers those files.
+                    - id: "ratelimiter-factory-typehint"
+                      title: "concrete RateLimiterFactory type-hint (autowiring aliases removed in Symfony 8.0)"
+                      regex: '(^|[ (,?\\])RateLimiterFactory[[:blank:]]+[$]'
+                      hint: 'Type-hint RateLimiterFactoryInterface instead - it exists since Symfony 7.3 and create() is identical'
+                    - id: "ratelimiter-factory-import"
+                      title: "concrete RateLimiterFactory import (aliases removed in Symfony 8.0)"
+                      regex: 'use Symfony\\Component\\RateLimiter\\RateLimiterFactory;'
+                      hint: 'Use Symfony\Component\RateLimiter\RateLimiterFactoryInterface'
+
                     # ── NEXT ENTRIES LAND HERE, one block per completed fix sweep ──
 
         steps:


### PR DESCRIPTION
## What

Adds two `api-scan` rules banning injection of the **concrete** `RateLimiterFactory`:

| id | bans | since |
|---|---|---|
| `ratelimiter-factory-typehint` | `RateLimiterFactory $x` as a parameter/property type | Symfony **8.0** |
| `ratelimiter-factory-import` | `use Symfony\Component\RateLimiter\RateLimiterFactory;` | Symfony **8.0** |

**Matrix entries only — no engine change.** This is the ratchet working as designed: the two existing
scan engines cover this break, so a sweep costs one YAML block.

Shipping this *before* the fix PRs, as with the voter rule, so each fix PR is validated by the rule it
satisfies.

## Why

Symfony 8.0 removes the autowiring aliases for `RateLimiterFactory` — `UPGRADE-8.0.md` says it twice, once
under FrameworkBundle and once under SecurityBundle: *"Remove autowiring aliases for `RateLimiterFactory`;
use `RateLimiterFactoryInterface` instead"*. Deprecated since 7.3.

Landing the fix is safe today, verified against the installed 7.4 tree (`symfony/rate-limiter v7.4.14`):
`RateLimiterFactoryInterface` has existed **since 7.3**, `final class RateLimiterFactory implements
RateLimiterFactoryInterface`, and its only method `create(?string $key = null): LimiterInterface` is
signature-identical. The platform calls nothing but `create()`.

Like the previous two sweeps, **neither PHPStan nor runtime deprecations surface this** at the call sites —
the deprecation fires on the alias, and only for autowired injections. Grep found it.

## The naming trap, inverted

Previous rules had to avoid matching Pimcore classes that *contain* a Symfony name. Here the danger is the
opposite: **the fixed form contains the banned one** — `RateLimiterFactoryInterface` starts with
`RateLimiterFactory`. A naive pattern would stay red forever after the fix. Both rules are anchored:

- **import**: trailing `;` — `...\RateLimiterFactory;` matches, `...\RateLimiterFactoryInterface;` does not
- **type-hint**: requires blank + `$` after the name — `RateLimiterFactory $x` matches,
  `RateLimiterFactoryInterface $x` does not, because the next character is `I`
- **leading `(^|[ (,?\\])`** rejects names that merely *end* in it — `McpAuthRateLimiterFactory`,
  `CompoundRateLimiterFactory` — while still matching fully-qualified use
  (`\Symfony\Component\RateLimiter\RateLimiterFactory $f`)

## Known limitation, deliberate

A **return type** is not matched — `): ?RateLimiterFactory` has no `$` after it. Any file using the type
must import it, so the import rule flags the file regardless; the platform's single return-type site
(`RateLimitSubscriber::resolveLimiterFactory()`) is fixed in the accompanying sweep. Also deliberate:
`new RateLimiterFactory(...)` is **not** banned — instantiation stays legal in 8.0, and the platform's six
test files do exactly that.

## Verification

Gates ran the `api-scan` run-block extracted from **this file** — the shipped code, not a copy — against
the current `2026.x` heads:

| case | typehint | import |
|---|---|---|
| `studio-backend-bundle` | 7 hits | 6 hits |
| `openid-connect` | 2 | 2 |
| `data-hub-simple-rest` | 1 | 1 |
| `pimcore`, `object-merger`, `quill-bundle`, `portal-engine` | 0 | 0 |
| all three repos **with the fix applied** | **0** | **0** |
| fixture file (13 cases) | 3 (plain, wrapped, FQCN) | 1 |

The post-fix row is the important one: it proves the interface does not re-trigger the rules. The fixtures
additionally pin the decoys (`McpAuthRateLimiterFactory`, `CompoundRateLimiterFactory`), the three
already-migrated forms, `new RateLimiterFactory(...)`, a return type and a same-named string variable as
non-matches. The three previously shipped rules were re-checked and stay green.

## Expected consequence after merge

`studio-backend-bundle`, `openid-connect` and `data-hub-simple-rest` go **red on `2026.x`** until their fix
PRs land — 9 files, one PR per repo, following immediately. The other 35 repos stay green. That red is the
intended signal and the live proof the rules fire.

One of those fixes touches public API: studio-backend's `User\RateLimiter\RateLimiterInterface::check()`
exposes the concrete type and carries no `@internal`, so widening it will be announced in that repo's
upgrade documentation.

## Context

Sweep 3 of the Symfony 7.4 → 8 migration (`pimcore/platform-version`, `migration-analysis/SUMMARY.md` §3,
runbook `EXEC-RATELIMITER.md`). Sweeps 1 and 2 — `#[TaggedIterator]` → `#[AutowireIterator]` and the voter
`?Vote` argument — are merged across the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
