### PR TITLE
[Symfony 8] Ban the deprecated HttpKernel DI Extension base class

### DIFF
--- a/.github/workflows/reusable-symfony8-compat.yaml
+++ b/.github/workflows/reusable-symfony8-compat.yaml
@@ -84,6 +84,16 @@ jobs:
                       regex: 'use Symfony\\Component\\DependencyInjection\\Attribute\\TaggedIterator;'
                       hint: 'Use Symfony\Component\DependencyInjection\Attribute\AutowireIterator'
 
+                    # ── Symfony 8.1: HttpKernel's DI Extension base class deprecated ──
+                    # Terminated by ";" or a blank so an "as Alias" import still matches, while
+                    # ConfigurableExtension (same namespace, SEPARATE deprecation) and longer
+                    # names such as ExtensionInterface cannot. Only the import changes in a fix:
+                    # the new parent has the same short name and is the deprecated class's parent.
+                    - id: "httpkernel-extension-import"
+                      title: "HttpKernel DI Extension base class (deprecated in Symfony 8.1)"
+                      regex: 'use Symfony\\Component\\HttpKernel\\DependencyInjection\\Extension(;|[[:blank:]])'
+                      hint: 'Extend Symfony\Component\DependencyInjection\Extension\Extension instead - it is the deprecated class own parent, so only the import line changes'
+
                     # ── NEXT ENTRIES LAND HERE, one block per completed fix sweep ──
 
         steps:


### PR DESCRIPTION
## What

One new `api-scan` rule banning the deprecated HttpKernel DI extension base class:

| id | bans | since |
|---|---|---|
| `httpkernel-extension-import` | `use Symfony\Component\HttpKernel\DependencyInjection\Extension;` | deprecated in Symfony **8.1** |

**Matrix entry only — no engine change.** Third sweep in a row where adding a rule costs one YAML block.

Shipping this before the fix PRs, as with the previous rules, so each fix PR is validated by the rule it
satisfies.

## Why the fix it demands is unusually safe

`Symfony\Component\DependencyInjection\Extension\Extension` **already exists in 7.4 and is the deprecated
class's own parent** — from the installed vendor tree:

```php
// vendor/symfony/http-kernel/DependencyInjection/Extension.php:23
abstract class Extension extends BaseExtension        // BaseExtension = the DependencyInjection one
```

So the fix removes a deprecated intermediate from the hierarchy. `instanceof` results are unchanged,
behaviour is unchanged, and **only the import line changes** — `class X extends Extension` stays exactly as
written, because the new parent has the same short name.

No public API is involved: every bundle's DI extension class is internal plumbing that integrators do not
extend, and platform-wide there are no aliases, grouped imports, FQCN uses, `instanceof Extension`, or
parameter/property/docblock references to the abstract base. That matters here specifically — the previous
sweep was reverted because widening a public, cross-repo-consumed interface turned out to need release
ordering. This one has none of that shape.

## The anchoring, which is the whole trick

The terminator `(;|[[:blank:]])` makes the rule catch a hypothetical `...\Extension as Base;` — still the
deprecated class — while **`ConfigurableExtension`, which lives in the same namespace and is a separate
deprecation, cannot match**, nor can any longer name such as `ExtensionInterface`.

That distinction is load-bearing: 7 bundles and 4 core bundles extend `ConfigurableExtension`, and one repo
(`translations-provider-interfaces`) carries **both** — the fix touches its `src/` extension and leaves its
`bundles/XliffBundle` one alone.

No companion "extends" rule is needed: that token is identical before and after the fix, and every
violating file is identified by its import.

## Verification

Gates ran the `api-scan` run-block extracted from **this file** — the shipped code, not a copy:

| case | result |
|---|---|
| the 19 affected repos | exit 1, **exactly 1 hit each** |
| `pimcore` core + all 7 `ConfigurableExtension` carriers + 2 already-migrated bundles | exit 0, clean |
| `pimcore-agent-bundle` (PHP already migrated) | exit 0 — its stale docs sample is correctly **not** counted, the engine is PHP-only |
| all 19 repos **with the fix applied** | exit 0, clean |
| fixture file (6 import forms) | exactly the plain and aliased deprecated imports flagged |

The three previously shipped rules were re-checked against the fixed copies and stay green.

## Expected consequence after merge

**19 repos go red on `2026.x`** until their one-line fix PRs land; core, the `ConfigurableExtension`
carriers, the 10 already-migrated bundles and `pimcore-agent-bundle` stay green. That red is the intended
signal and the live proof the rule fires.

## Context

Sweep 4 of the Symfony 7.4 → 8 migration (`pimcore/platform-version`, runbook `EXEC-EXTENSION.md`), chosen
from a review of what remains doable **without any BC break**. Sweeps 1 and 2 (`#[TaggedIterator]` →
`#[AutowireIterator]`; the voter `?Vote` argument) are merged; sweep 3 (RateLimiterFactory) was deliberately
backed out — see `EXEC-RATELIMITER.md` §7.

Not in scope, tracked separately: `ConfigurableExtension` (its own deprecation) and
`HttpKernel\Bundle\BundleInterface` (**bump-time only** — the replacement interface does not exist in 7.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
