### PR TITLE
Move workflow notifications to the GitHub Workflow Notifications channel

### DIFF
--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -142,6 +142,7 @@ jobs:
                 TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
                 RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
+                set -o pipefail
                 TEXT=$(printf 'Please check the following link for details:\n%s\n\n**Outdated dependencies found:**\n```\n%s\n```\nIf the list is too long, please refer to the link above.' \
                        "$RUN_URL" "${OUTDATED_ENV:-}")
                 jq -n --arg ti "$TITLE" --arg t "$TEXT" '{
@@ -153,9 +154,3 @@ jobs:
                 }' | curl -sS --fail --retry 4 --retry-delay 5 --retry-all-errors \
                        -H 'Content-Type: application/json' -d @- "$WEBHOOK"
 
-            # The outdated check is continue-on-error so the notification can run, so the job needs an
-            # explicit failure here. Until now the job only went red because the Teams step itself
-            # errored against the retired connector — fixing delivery would have made it silently green.
-            - name: "Check results of previous checks"
-              if: steps.dependencies.outcome == 'failure'
-              run: exit 1

--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -132,7 +132,7 @@ jobs:
                     exit 1
                 fi
 
-            # Posts to the "GitHub Workflow Notifications" channel. Same MessageCard + curl as
+            # Posts to the "Workflow Notifications" channel. Same MessageCard + curl as
             # reusable-teams-notify.yaml, inlined because a reusable workflow cannot be a step.
             # Replaces aliencube/microsoft-teams-actions, which POSTed to a retired O365 connector.
             - name: Send results of previous checks to Microsoft Teams

--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -132,19 +132,30 @@ jobs:
                     exit 1
                 fi
 
+            # Posts to the "GitHub Workflow Notifications" channel. Same MessageCard + curl as
+            # reusable-teams-notify.yaml, inlined because a reusable workflow cannot be a step.
+            # Replaces aliencube/microsoft-teams-actions, which POSTed to a retired O365 connector.
             - name: Send results of previous checks to Microsoft Teams
               if: steps.dependencies.outcome == 'failure'
-              uses: aliencube/microsoft-teams-actions@v0.8.0
-              with:
-                webhook_uri: ${{ secrets.TEAMS_COMPOSER_OUTDATED_URI }}
-                title: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
-                summary: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}} 
-                text: |
-                  Please check the following link for details: 
-                  ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
-                  
-                  **Outdated dependencies found:**
-                  ```
-                  ${{ env.OUTDATED_ENV }}
-                  ```            
-                  If the list is too long, please refer to the link above.
+              env:
+                WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
+                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
+                RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                TEXT=$(printf 'Please check the following link for details:\n%s\n\n**Outdated dependencies found:**\n```\n%s\n```\nIf the list is too long, please refer to the link above.' \
+                       "$RUN_URL" "${OUTDATED_ENV:-}")
+                jq -n --arg ti "$TITLE" --arg t "$TEXT" '{
+                  "@type": "MessageCard",
+                  "@context": "http://schema.org/extensions",
+                  summary: $ti,
+                  title: $ti,
+                  text: $t
+                }' | curl -sS --fail --retry 4 --retry-delay 5 --retry-all-errors \
+                       -H 'Content-Type: application/json' -d @- "$WEBHOOK"
+
+            # The outdated check is continue-on-error so the notification can run, so the job needs an
+            # explicit failure here. Until now the job only went red because the Teams step itself
+            # errored against the retired connector — fixing delivery would have made it silently green.
+            - name: "Check results of previous checks"
+              if: steps.dependencies.outcome == 'failure'
+              run: exit 1

--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -27,6 +27,16 @@ on:
               required: false
               default: false
               type: boolean
+        # Declared so callers can pass only what they need instead of `secrets: inherit`.
+        # All optional: callers that inherit satisfy them implicitly, and the two private-repo
+        # secrets are only read when `private-repo: true`.
+        secrets:
+            TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI:
+              required: false
+            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER:
+              required: false
+            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN:
+              required: false
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -142,6 +142,7 @@ jobs:
                 TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
                 RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
+                set -o pipefail
                 TEXT=$(printf 'Please check the following link for details:\n%s\n\n**Outdated dependencies found:**\n```\n%s\n```\nIf the list is too long, please refer to the link above.' \
                        "$RUN_URL" "${OUTDATED_ENV:-}")
                 jq -n --arg ti "$TITLE" --arg t "$TEXT" '{
@@ -153,9 +154,3 @@ jobs:
                 }' | curl -sS --fail --retry 4 --retry-delay 5 --retry-all-errors \
                        -H 'Content-Type: application/json' -d @- "$WEBHOOK"
 
-            # The outdated check is continue-on-error so the notification can run, so the job needs an
-            # explicit failure here. Until now the job only went red because the Teams step itself
-            # errored against the retired connector — fixing delivery would have made it silently green.
-            - name: "Check results of previous checks"
-              if: steps.dependencies.outcome == 'failure'
-              run: exit 1

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -132,7 +132,7 @@ jobs:
                     exit 1
                 fi
 
-            # Posts to the "GitHub Workflow Notifications" channel. Same MessageCard + curl as
+            # Posts to the "Workflow Notifications" channel. Same MessageCard + curl as
             # reusable-teams-notify.yaml, inlined because a reusable workflow cannot be a step.
             # Replaces aliencube/microsoft-teams-actions, which POSTed to a retired O365 connector.
             - name: Send results of previous checks to Microsoft Teams

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -132,19 +132,30 @@ jobs:
                     exit 1
                 fi
 
+            # Posts to the "GitHub Workflow Notifications" channel. Same MessageCard + curl as
+            # reusable-teams-notify.yaml, inlined because a reusable workflow cannot be a step.
+            # Replaces aliencube/microsoft-teams-actions, which POSTed to a retired O365 connector.
             - name: Send results of previous checks to Microsoft Teams
               if: steps.dependencies.outcome == 'failure'
-              uses: aliencube/microsoft-teams-actions@v0.8.0
-              with:
-                webhook_uri: ${{ secrets.TEAMS_COMPOSER_OUTDATED_URI }}
-                title: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
-                summary: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}} 
-                text: |
-                  Please check the following link for details: 
-                  ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
-                  
-                  **Outdated dependencies found:**
-                  ```
-                  ${{ env.OUTDATED_ENV }}
-                  ```            
-                  If the list is too long, please refer to the link above.
+              env:
+                WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
+                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
+                RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                TEXT=$(printf 'Please check the following link for details:\n%s\n\n**Outdated dependencies found:**\n```\n%s\n```\nIf the list is too long, please refer to the link above.' \
+                       "$RUN_URL" "${OUTDATED_ENV:-}")
+                jq -n --arg ti "$TITLE" --arg t "$TEXT" '{
+                  "@type": "MessageCard",
+                  "@context": "http://schema.org/extensions",
+                  summary: $ti,
+                  title: $ti,
+                  text: $t
+                }' | curl -sS --fail --retry 4 --retry-delay 5 --retry-all-errors \
+                       -H 'Content-Type: application/json' -d @- "$WEBHOOK"
+
+            # The outdated check is continue-on-error so the notification can run, so the job needs an
+            # explicit failure here. Until now the job only went red because the Teams step itself
+            # errored against the retired connector — fixing delivery would have made it silently green.
+            - name: "Check results of previous checks"
+              if: steps.dependencies.outcome == 'failure'
+              run: exit 1

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -27,6 +27,16 @@ on:
               required: false
               default: false
               type: boolean
+        # Declared so callers can pass only what they need instead of `secrets: inherit`.
+        # All optional: callers that inherit satisfy them implicitly, and the two private-repo
+        # secrets are only read when `private-repo: true`.
+        secrets:
+            TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI:
+              required: false
+            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER:
+              required: false
+            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN:
+              required: false
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-teams-notify.yaml
+++ b/.github/workflows/reusable-teams-notify.yaml
@@ -12,7 +12,7 @@ on:
         type: string
         required: true
     # Callers use `secrets: inherit`; this reads TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI
-    # directly — the webhook of the "GitHub Workflow Notifications" channel (org secret).
+    # directly — the webhook of the "Workflow Notifications" channel (org secret).
 
 jobs:
   notify:

--- a/.github/workflows/reusable-teams-notify.yaml
+++ b/.github/workflows/reusable-teams-notify.yaml
@@ -11,7 +11,8 @@ on:
         description: 'Message body (markdown)'
         type: string
         required: true
-    # Callers use `secrets: inherit`; this reads TEAMS_WORKFLOWS_WEBHOOK_URI directly.
+    # Callers use `secrets: inherit`; this reads TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI
+    # directly — the webhook of the "GitHub Workflow Notifications" channel (org secret).
 
 jobs:
   notify:
@@ -19,7 +20,7 @@ jobs:
     steps:
       - name: Post to Teams
         env:
-          WEBHOOK: ${{ secrets.TEAMS_WORKFLOWS_WEBHOOK_URI }}
+          WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
           TITLE: ${{ inputs.title }}
           TEXT: ${{ inputs.text }}
         run: |

--- a/.github/workflows/reusable-teams-notify.yaml
+++ b/.github/workflows/reusable-teams-notify.yaml
@@ -24,6 +24,7 @@ jobs:
           TITLE: ${{ inputs.title }}
           TEXT: ${{ inputs.text }}
         run: |
+          set -o pipefail
           jq -n --arg ti "$TITLE" --arg t "$TEXT" '{
             "@type": "MessageCard",
             "@context": "http://schema.org/extensions",


### PR DESCRIPTION
Last of three PRs for pimcore/service-operations#1135 — workflow notifications move to the
**Workflow Notifications** Teams channel. product-management#1423 and workflows-centralized#54
are already merged and delivering.

### Two changes

**1. `reusable-teams-notify.yaml`** — reads the org secret
`TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI` instead of `TEAMS_WORKFLOWS_WEBHOOK_URI`.
One line. Callers untouched.

**2. Both `reusable-composer-checks` workflows** — their Teams notification was dead. They posted via
`aliencube/microsoft-teams-actions` to a retired O365 connector, so `pimcore/pimcore`'s
composer-outdated check has failed **23 runs straight since 2026-03-13** (last success 2026-03-06)
with `500 (Internal Server Error)`. Replaced with the same `curl` + MessageCard that
`reusable-teams-notify.yaml` uses, on the new secret.

Job outcome is deliberately unchanged: outdated dependencies → card posted → run **green**, which is
what run `22753273820` (the last pre-breakage run) did. The red runs since March were the dead
connector, not a signal. An earlier revision of this PR added an `exit 1` to "keep" that red; it was
dropped, because it would have made all 14 caller workflows permanently red — the callers use
`version-type: -M`, so a newer major is nearly always available — and `check-workflow-runs` would then
report those failures into this very channel every day.

**3. Declared `workflow_call` secrets** on both composer reusables —
`TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI` plus the two `private-repo`-only ones, all optional.
SonarCloud flags `secrets: inherit` on callers ("Only pass required secrets to this workflow"), and a
caller can only pass secrets explicitly if the called workflow declares them. Backward compatible: the
13 callers using `inherit` keep working, since inherit satisfies declared secrets too.

### Blast radius

14 caller workflows across 8 repos reach these reusables via `@main` (nothing SHA-pinned), so they all
switch on merge. 13 of 14 inherit secrets and need no change. The exception is
`data-quality-management-bundle`, which passes no `secrets:` at all — fixed in
pimcore/data-quality-management-bundle#331, which should merge alongside this.

### Verification

- Org secret exists and is readable by every affected repo ✓
- Payload proven against the live webhook: two cards delivered and visible in the channel ✓
- YAML parses; both new `run` blocks pass `bash -n`; payload rendered locally against multi-line
  `composer outdated` output ✓
- `set -o pipefail` added to the notification steps: GitHub's default shell is `bash -e {0}` without
  pipefail, so a `jq` failure would otherwise be swallowed and `curl` would POST an empty body — which
  Power Automate answers `202`, i.e. a green step that delivered nothing.

Known limitation: `curl --fail` cannot confirm delivery. A Power Automate webhook returns `202` as soon
as the request is queued, before the flow runs, so a green step means "accepted", not "posted". The
channel is the only real check — which is why the first post-merge run wants eyes on it:

```bash
gh workflow run composer-checks-outdated.yaml -R pimcore/pimcore --ref 2026.x
```

> [!NOTE]
> **Merge before pimcore/data-quality-management-bundle#331.** That PR passes the webhook secret by
> name, which is a hard error until this PR declares it.

### Follow-up

`TEAMS_COMPOSER_OUTDATED_URI` and `TEAMS_COMPOSER_VULNERABILITY_URI` stop being read on any default
branch once this merges. They are not safe to delete on that basis alone — 33 stale branches here still
reference them, and each old webhook pointed at its own channel, so deleting also retires that
destination. Tracked in pimcore/DevOps-Tasks#29.
