### PR TITLE
Send vulnerability reports to github-vulnerabilities-report, and align card titles

### DIFF
--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -149,7 +149,7 @@ jobs:
               if: steps.dependencies.outcome == 'failure'
               env:
                 WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
-                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
+                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated dependencies report
                 RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                 set -o pipefail

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -149,7 +149,7 @@ jobs:
               if: steps.dependencies.outcome == 'failure'
               env:
                 WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
-                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
+                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated dependencies report
                 RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                 set -o pipefail

--- a/.github/workflows/reusable-composer-vulnerabilities.yaml
+++ b/.github/workflows/reusable-composer-vulnerabilities.yaml
@@ -151,6 +151,6 @@ jobs:
         if: ${{ needs.composer-checks.outputs.has_vulnerabilities == 'true' }}
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-teams-notify.yaml@main
         with:
-          title: "${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report"
+          title: "${{ github.repository }}@${{ inputs.branch }} vulnerabilities report"
           text: ${{ needs.composer-checks.outputs.vulnerabilities_text }}
         secrets: inherit

--- a/.github/workflows/reusable-teams-notify.yaml
+++ b/.github/workflows/reusable-teams-notify.yaml
@@ -11,8 +11,11 @@ on:
         description: 'Message body (markdown)'
         type: string
         required: true
-    # Callers use `secrets: inherit`; this reads TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI
-    # directly — the webhook of the "Workflow Notifications" channel (org secret).
+    # Callers use `secrets: inherit`; this reads TEAMS_WORKFLOWS_WEBHOOK_URI directly — the
+    # caller's webhook for the "github-vulnerabilities-report" channel. Both callers
+    # (reusable-osv-checks, reusable-composer-vulnerabilities) are vulnerability reports, which
+    # deliberately stay in that channel; only workflow-status reports moved to the new
+    # "Workflow Notifications" channel (service-operations#1135).
 
 jobs:
   notify:
@@ -20,7 +23,7 @@ jobs:
     steps:
       - name: Post to Teams
         env:
-          WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
+          WEBHOOK: ${{ secrets.TEAMS_WORKFLOWS_WEBHOOK_URI }}
           TITLE: ${{ inputs.title }}
           TEXT: ${{ inputs.text }}
         run: |


### PR DESCRIPTION
Follow-up to #1135, which moved workflow-status notifications to the new **Workflow Notifications** Teams channel. That move also switched `reusable-teams-notify.yaml` to the new webhook — but both of its callers are *vulnerability* reports, which should have stayed put.

## Two fixes

**1. Vulnerability reports go back to `github-vulnerabilities-report`**

`reusable-teams-notify.yaml` reads `TEAMS_WORKFLOWS_WEBHOOK_URI` again instead of `TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI`. Its only two callers — `reusable-osv-checks` and `reusable-composer-vulnerabilities` — are both vulnerability reports, so the whole workflow belongs on the vulnerabilities channel.

Only *workflow-status* reporting moved to the new channel. That path is the inlined curl step in `reusable-composer-checks` / `reusable-composer-recursive-checks`, which is untouched here and still posts to Workflow Notifications.

**2. Cards are named after what they actually check**

| Workflow | Before | After |
|---|---|---|
| `reusable-composer-checks` | `… outdated - vulnerabilities report` | `… outdated dependencies report` |
| `reusable-composer-recursive-checks` | `… outdated - vulnerabilities report` | `… outdated dependencies report` |
| `reusable-composer-vulnerabilities` | `… outdated - vulnerabilities report` | `… vulnerabilities report` |

The outdated-dependency cards were labelled "vulnerabilities report" but report neither vulnerabilities nor anything security-related — just packages behind their latest version. With both kinds of card previously landing in one channel under one title, an outdated-dependency notice read as a security finding.

## Notes

- Config only: 4 workflow files, no logic changes.
- `TEAMS_WORKFLOWS_WEBHOOK_URI` and `TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI` both already exist as org secrets — nothing to provision.
- Worth confirming after merge that the next vulnerability report lands in `github-vulnerabilities-report` and the next outdated-dependency report lands in Workflow Notifications.

Refs pimcore/service-operations#1135
