### PR TITLE
Name the composer cards after what they actually check

### DIFF
--- a/.github/workflows/reusable-composer-checks.yaml
+++ b/.github/workflows/reusable-composer-checks.yaml
@@ -149,7 +149,7 @@ jobs:
               if: steps.dependencies.outcome == 'failure'
               env:
                 WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
-                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
+                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated dependencies report
                 RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                 set -o pipefail

--- a/.github/workflows/reusable-composer-recursive-checks.yaml
+++ b/.github/workflows/reusable-composer-recursive-checks.yaml
@@ -149,7 +149,7 @@ jobs:
               if: steps.dependencies.outcome == 'failure'
               env:
                 WEBHOOK: ${{ secrets.TEAMS_GITHUB_WORKFLOW_NOTIFICATIONS_WEBHOOK_URI }}
-                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report
+                TITLE: ${{ github.repository }}@${{ inputs.branch }} outdated dependencies report
                 RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                 set -o pipefail

--- a/.github/workflows/reusable-composer-vulnerabilities.yaml
+++ b/.github/workflows/reusable-composer-vulnerabilities.yaml
@@ -151,6 +151,6 @@ jobs:
         if: ${{ needs.composer-checks.outputs.has_vulnerabilities == 'true' }}
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-teams-notify.yaml@main
         with:
-          title: "${{ github.repository }}@${{ inputs.branch }} outdated - vulnerabilities report"
+          title: "${{ github.repository }}@${{ inputs.branch }} vulnerabilities report"
           text: ${{ needs.composer-checks.outputs.vulnerabilities_text }}
         secrets: inherit


### PR DESCRIPTION
Follow-up to pimcore/service-operations#1135.

A card titled `pimcore/pimcore@2026.2 outdated - vulnerabilities report` arrived in **Workflow
Notifications** and looked misrouted. It wasn't — it came from `reusable-composer-checks.yaml`, which
runs only `composer outdated`. The title was wrong, not the channel.

Both titles had borrowed the other's words:

| Workflow | Runs | Was | Now |
|---|---|---|---|
| `reusable-composer-checks` / `-recursive-checks` | `composer outdated` | outdated - **vulnerabilities** report | outdated dependencies report |
| `reusable-composer-vulnerabilities` | `composer audit` | **outdated** - vulnerabilities report | vulnerabilities report |

This matters now that the two channels are separate: anything calling itself a vulnerabilities report
should be in `github-vulnerabilities-report`, and anything in Workflow Notifications should not claim to
be one.

Title text only — no routing or logic change. The mislabelling was invisible for the five months the
notifications were dead.
