### PR TITLE
Sync repo-guardrails.yml to pimcore_test too

### DIFF
--- a/.github/sync-config.yaml
+++ b/.github/sync-config.yaml
@@ -47,7 +47,7 @@ group:
   # wherever the PR guardrails already do, minus two deliberate exclusions:
   #   - pimcore/platform-version — the issue-of-record repo, where the guardrail is
   #     a config-driven no-op; running it on every issue there is pure noise.
-  #   - pimcore/pimcore_test — validation target, wired up by hand ahead of rollout.
+
   # Re-derive the list with:
   #   gh api --paginate 'orgs/pimcore/repos?per_page=100&type=all' \
   #     --jq '.[]|select(.archived==false)|.full_name' | while read -r r; do \
@@ -104,6 +104,7 @@ group:
       pimcore/perspective-editor
       pimcore/pimcore
       pimcore/pimcore-agent-bundle
+      pimcore/pimcore_test
       pimcore/portal-engine
       pimcore/quill-bundle
       pimcore/search-query-parser


### PR DESCRIPTION
pimcore_test was excluded from the repo-guardrails rollout as the planned validation target, wired up by hand. Validation ended up happening on pimcore/number-sequence-generator instead (public repo — a non-member can open issues there via CLI with zero setup), so the hand-wiring never landed and pimcore_test is now the only repo that has pr-guardrails.yml but no repo-guardrails.yml (platform-version stays excluded by design — it is the issue-of-record repo).

One line: add pimcore_test to the sync group. Merging triggers the sync, which opens the standard single-file PR there.

The guardrail was validated end-to-end today: 3× non-member issue closed with redirect comment + label, 1× member issue untouched, log evidence for both paths (see pimcore/service-operations#1125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)