### PR TITLE
Let the packaged frontend build run tests too

### DIFF
--- a/.github/workflows/reusable-studio-frontend-build-packaged.yaml
+++ b/.github/workflows/reusable-studio-frontend-build-packaged.yaml
@@ -55,6 +55,16 @@ on:
         required: false
         type: string
         default: "package-build"
+      test:
+        description: "Run tests after build"
+        required: false
+        type: boolean
+        default: false
+      test-script:
+        description: "NPM script to run for tests"
+        required: false
+        type: string
+        default: "test"
       commit-lint-output:
         description: "Automatically commit lint fixes"
         required: false
@@ -335,3 +345,39 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           file_pattern: ${{ inputs.build-output-path }}
           commit_message: Automatic frontend build
+
+  # Read-only: runs the repo's test script after the build (and after any build
+  # output has been committed). No write token here.
+  # NOTE: this job checks out the branch fresh and does NOT re-run the build. If
+  # the test script consumes build artifacts, enable commit-build-output so the
+  # output is committed first; otherwise (or on fork PRs, where commit-build is
+  # skipped) the checkout has no fresh build. studio-ui's jest runs against
+  # source, so it does not depend on the build output.
+  test:
+    needs:
+      - build
+      - commit-build
+    if: ${{ !cancelled() && inputs.test && !startsWith(github.ref, 'refs/tags/') && needs.build.result == 'success' && (needs.commit-build.result == 'success' || needs.commit-build.result == 'skipped') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.1
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          # Runs repo-provided code (npm hooks + test script); no authenticated
+          # git needed after checkout.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Run tests
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run ${{ inputs.test-script }}


### PR DESCRIPTION
## The gap

`reusable-studio-frontend-build-packaged.yaml` has no `test` job. A bundle on this workflow cannot run its unit tests in CI **at all** — there is no input to enable, so it is not a misconfiguration on the caller side.

Its sibling `reusable-studio-frontend-build.yaml` has had one since it was added. The two files have drifted:

| input | `-build.yaml` | `-build-packaged.yaml` |
|---|---|---|
| `test` / `test-script` | ✅ | ❌ → added here |
| `api-client` / `api-client-script` | ✅ | ❌ (left out, see below) |
| `package-script` | ❌ | ✅ |
| `build-output-path` default | `.` | `./build-dist/` |

Found while auditing `pimcore/collab-bundle`, which has 14 Jest suites / 120 passing tests that gate nothing. Its `static-analysis.yaml` also carries `paths-ignore: assets/**`, so a frontend-only PR there triggers only this build workflow — meaning the frontend is currently unverified end to end. Any other bundle on the packaged flow has the same silent gap.

## The change

Purely additive — 46 lines, no deletions:

- `test` (boolean, default `false`) and `test-script` (string, default `"test"`) inputs
- the `test` job

Both are **copied verbatim** from `reusable-studio-frontend-build.yaml`; I diffed the job block and it is byte-identical to the version already running in production there. No new design.

## Why this is safe for existing callers

- `test` defaults to `false` — every current caller behaves exactly as before until it opts in
- the job is a leaf: nothing `needs` it, so it cannot perturb the existing graph
- it declares no `permissions` block — read-only, no write token, consistent with the sibling
- `CHECKOUT_REF` is already defined in this file (line 104), and the `build` / `commit-build` job names match, so the job's `needs:` and `if:` guard work unmodified

`yaml.safe_load` parses clean; jobs resolve to `lint, commit-lint, check-types, build, commit-build, test`.

## Deliberately not included

The sibling's `api-client` / `commit-api-client`, which the packaged variant also lacks. That job needs `contents: write` and is a real review rather than a copy, so it deserves its own PR. Flagging it here so the remaining drift is on the record.

## Follow-up

`pimcore/collab-bundle` will pass `test: true` once this lands. Draft until someone who owns this collection confirms the default should be `false` rather than `true` — defaulting to `true` would gate every packaged-flow bundle immediately, which is arguably the better outcome but a noisier landing and not my call.
